### PR TITLE
Maven improvements

### DIFF
--- a/Legacy/bonej/pom.xml
+++ b/Legacy/bonej/pom.xml
@@ -7,12 +7,11 @@
     <parent>
         <groupId>org.bonej</groupId>
         <artifactId>bonej-legacy</artifactId>
-        <version>1.0.0</version>
-        <relativePath>..</relativePath>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>boneJ-legacy-plugins</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <description> The essential, mavenized versions of the BoneJ1 plugins developed by Michael Doube</description>
 

--- a/Legacy/bonej/pom.xml
+++ b/Legacy/bonej/pom.xml
@@ -95,32 +95,26 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>3D_Viewer</artifactId>
-            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>AnalyzeSkeleton_</artifactId>
-            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>LocalThickness_</artifactId>
-            <version>4.0.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>Skeletonize3D_</artifactId>
-            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>VIB_</artifactId>
-            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>VIB-lib</artifactId>
-            <version>2.1.1</version>
         </dependency>
 
         <!-- Other dependencies -->

--- a/Legacy/bonej/pom.xml
+++ b/Legacy/bonej/pom.xml
@@ -78,13 +78,6 @@
         <system>Jenkins</system>
     </ciManagement>
 
-    <repositories>
-        <repository>
-            <id>imagej.public</id>
-            <url>http://maven.imagej.net/content/groups/public</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <!-- BoneJ dependencies -->
         <dependency>

--- a/Legacy/pom.xml
+++ b/Legacy/pom.xml
@@ -82,17 +82,17 @@
             <dependency>
                 <groupId>org.bonej</groupId>
                 <artifactId>boneJ-legacy-plugins</artifactId>
-                <version>1.0.0</version>
+                <version>${legacy-plugins.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bonej</groupId>
                 <artifactId>bonej-legacy-pqct</artifactId>
-                <version>1.0.0</version>
+                <version>${legacy-pqct.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bonej</groupId>
                 <artifactId>bonej-legacy-util</artifactId>
-                <version>1.0.0</version>
+                <version>${legacy-util.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -104,6 +104,9 @@
     <properties>
         <scijava.jvm.version>1.8</scijava.jvm.version>
         <javadoc.skip>true</javadoc.skip>
+        <legacy-util.version>1.0.0-SNAPSHOT</legacy-util.version>
+        <legacy-plugins.version>1.0.0-SNAPSHOT</legacy-plugins.version>
+        <legacy-pqct.version>1.0.0-SNAPSHOT</legacy-pqct.version>
     </properties>
 
     <modules>

--- a/Legacy/pom.xml
+++ b/Legacy/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.bonej</groupId>
     <artifactId>bonej-legacy</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>Parent POM for the mavenized legacy BoneJ1 code.</description>

--- a/Legacy/pom.xml
+++ b/Legacy/pom.xml
@@ -5,9 +5,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>net.imagej</groupId>
-        <artifactId>pom-imagej</artifactId>
-        <version>15.5.0</version>
+        <groupId>sc.fiji</groupId>
+        <artifactId>pom-fiji</artifactId>
+        <version>22.3.0</version>
     </parent>
 
     <groupId>org.bonej</groupId>

--- a/Legacy/pqct/pom.xml
+++ b/Legacy/pqct/pom.xml
@@ -7,12 +7,11 @@
     <parent>
         <groupId>org.bonej</groupId>
         <artifactId>bonej-legacy</artifactId>
-        <version>1.0.0</version>
-        <relativePath>..</relativePath>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bonej-legacy-pqct</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <description>BoneJ1 distribution of PQCT plugin</description>
 

--- a/Legacy/pqct/pom.xml
+++ b/Legacy/pqct/pom.xml
@@ -91,13 +91,6 @@
         <system>Jenkins</system>
     </ciManagement>
 
-    <repositories>
-        <repository>
-            <id>imagej.public</id>
-            <url>http://maven.imagej.net/content/groups/public</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <!-- BoneJ dependencies -->
         <dependency>

--- a/Legacy/util/pom.xml
+++ b/Legacy/util/pom.xml
@@ -8,12 +8,11 @@
     <parent>
         <groupId>org.bonej</groupId>
         <artifactId>bonej-legacy</artifactId>
-        <version>1.0.0</version>
-        <relativePath>..</relativePath>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bonej-legacy-util</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <description>The utility classes for BoneJ1 plugins. Partly in a separate module to avoid circular dependencies
     </description>

--- a/Legacy/util/pom.xml
+++ b/Legacy/util/pom.xml
@@ -66,13 +66,6 @@
         <system>Jenkins</system>
     </ciManagement>
 
-    <repositories>
-        <repository>
-            <id>imagej.public</id>
-            <url>http://maven.imagej.net/content/groups/public</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>

--- a/Legacy/util/pom.xml
+++ b/Legacy/util/pom.xml
@@ -28,12 +28,10 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>AnalyzeSkeleton_</artifactId>
-            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>Skeletonize3D_</artifactId>
-            <version>2.0.0</version>
         </dependency>
 
         <!-- Other dependencies -->


### PR DESCRIPTION
These changes move more control of Maven properties to the parent pom.xml.

To summarize:
* Remove relative pom path and add module properties so modules can be treated more independently
* Inherit from pom-fiji so most of the version specifications can be removed
* Remove inherited repository blocks from modules

This also sets the versions of all components to SNAPSHOTs.