### PR TITLE
Do not deploy the aggregator POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,10 @@
         <module>Modern</module>
     </modules>
 
+    <properties>
+      <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <profiles>
         <profile>
             <id>legacy</id>


### PR DESCRIPTION
It is not the parent for anything in the build, but rather only a convenience to build everything at once. As such, let's not deploy it.

Hopefully, this fixes the Travis build.