### PR TITLE
Mean Intercept Lengths op

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/mil/LineGrid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/mil/LineGrid.java
@@ -238,8 +238,10 @@ public final class LineGrid {
 			t.scale(sign);
 			final double range = 1.0 / bins;
 			final Builder<ValuePair<Point3d, Vector3d>> builder = Stream.builder();
-			for (double minC = 0.0; minC < 1.0; minC += range) {
-				for (double minD = 0.0; minD < 1.0; minD += range) {
+			for (int i = 0; i < bins; i++) {
+				final double minC = i * range;
+				for (int j = 0; j < bins; j++) {
+					final double minD = j * range;
 					final double c = (rng.nextDouble() * range + minC) * size - 0.5 *
 						size;
 					final double d = (rng.nextDouble() * range + minD) * size - 0.5 *

--- a/Modern/ops/src/main/java/org/bonej/ops/mil/MILGrid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/mil/MILGrid.java
@@ -1,0 +1,266 @@
+
+package org.bonej.ops.mil;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import net.imagej.ops.Contingent;
+import net.imagej.ops.Op;
+import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
+import net.imagej.ops.special.function.BinaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.hybrid.BinaryHybridCFI1;
+import net.imagej.ops.special.hybrid.Hybrids;
+import net.imglib2.Interval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.util.ValuePair;
+
+import org.bonej.ops.BoxIntersect;
+import org.bonej.ops.RotateAboutAxis;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.vecmath.AxisAngle4d;
+import org.scijava.vecmath.Point3d;
+import org.scijava.vecmath.Tuple3d;
+import org.scijava.vecmath.Vector3d;
+
+/**
+ * Creates a cloud of mean intercept length (MIL) vectors that describes the
+ * anisotropy of the interval.
+ * <p>
+ * First using the {@link LineGrid} class the op draws a grid of lines that
+ * intercept the interval. Then for each line it counts how many time it
+ * intercepts objects in the interval. The intercepts are found by sampling
+ * elements in the interval along the lines. The method is not exact, because it
+ * may not sample each element. Each time the previous sample was background and
+ * the current is foreground -- or vice-versa -- the intercept count is
+ * increment. Thus when a line enters and exits a foreground object it counts as
+ * two intercepts.
+ * </p>
+ * <p>
+ * Next each line is mapped to a unit vector centered on the origin. The vector
+ * has the same direction as the line. The vectors are then divided by the
+ * number of intercepts. Lines that sample the interval less than two times are
+ * ignored. These vectors form the mean intercept length point cloud. In a
+ * completely isotropic interval all of them will be unit vectors.
+ * </p>
+ *
+ * @author Richard Domander
+ */
+@Plugin(type = Op.class)
+public class MILGrid<B extends BooleanType<B>> extends
+	AbstractUnaryFunctionOp<RandomAccessibleInterval<B>, List<Vector3d>>
+	implements Contingent
+{
+
+	/**
+	 * Number lines drawn from the planes of the grid. For example, if
+	 * linesPerDimension = 2 then 2 * 2 lines are drawn from each plane - a total
+	 * of 2 * 2 * 3 = 12.
+	 * <p>
+	 * If left null, the parameter is set to the size of the biggest dimension of
+	 * the interval.
+	 * </p>
+	 * 
+	 * @see LineGrid#lines(long)
+	 */
+	@Parameter(required = false, persist = false)
+	private Long linesPerDimension;
+	/**
+	 * The scalar step between the sample positions. For example, an increment of
+	 * 1.0 adds a vector of length 1.0 to the position. The increment is to the
+	 * same direction as the line.
+	 * <p>
+	 * If left null, the increment is set to 1.0.
+	 * </p>
+	 */
+	@Parameter(required = false, persist = false)
+	private Double samplingIncrement;
+	/**
+	 * A rotation applied to the grid.
+	 * <p>
+	 * If left null, a random rotation is used.
+	 * </p>
+	 */
+	@Parameter(required = false, persist = false)
+	private AxisAngle4d gridRotation;
+	/**
+	 * The random generator used in the method.
+	 * <p>
+	 * If left null, a new generator is created with the default constructor.
+	 * </p>
+	 */
+	@Parameter(required = false, persist = false)
+	private Random random;
+
+	/**
+	 * Finds the MIL vectors of the interval.
+	 *
+	 * @param interval an interval with at least three dimensions. The method
+	 *          assumes that the first three are X,Y and Z. It ignores others.
+	 * @return a cloud of MIL vectors around the origin.
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<Vector3d> calculate(final RandomAccessibleInterval<B> interval) {
+		final BinaryHybridCFI1<Tuple3d, AxisAngle4d, Tuple3d> rotateOp;
+		final BinaryFunctionOp<ValuePair<Point3d, Vector3d>, Interval, Optional<ValuePair<DoubleType, DoubleType>>> intersectOp;
+		final AxisAngle4d rotation;
+		final long bins;
+		final double increment;
+		final Random rng;
+		synchronized (this) {
+			rotateOp = Hybrids.binaryCFI1(ops(), RotateAboutAxis.class, Tuple3d.class,
+				new Vector3d(), new AxisAngle4d());
+			intersectOp = (BinaryFunctionOp) Functions.binary(ops(),
+				BoxIntersect.class, Optional.class, ValuePair.class, interval);
+			rotation = gridRotation != null ? gridRotation : RotateAboutAxis
+				.randomAxisAngle();
+			final long defaultBins = LongStream.of(interval.dimension(0), interval
+				.dimension(1), interval.dimension(2)).max().orElse(0);
+			bins = linesPerDimension != null ? linesPerDimension : defaultBins;
+			increment = samplingIncrement != null ? samplingIncrement : 1.0;
+			rng = random != null ? random : new Random();
+		}
+		final LineGrid grid = createGrid(interval, rotateOp, rotation, rng);
+		final Stream<Section> sections = grid.lines(bins).map((line) -> findSection(
+			line, interval, intersectOp)).filter(Objects::nonNull);
+		return sections.map(section -> toMILVector(section, interval, increment,
+			random)).filter(Objects::nonNull).collect(toList());
+	}
+
+	@Override
+	public boolean conforms() {
+		return in().numDimensions() >= 3;
+	}
+
+	// region -- Helper methods --
+	private static LineGrid createGrid(final Interval interval,
+		final BinaryHybridCFI1<Tuple3d, AxisAngle4d, Tuple3d> rotateOp,
+		final AxisAngle4d rotation, final Random rng)
+	{
+		final LineGrid grid = new LineGrid(interval);
+		grid.setRandomGenerator(rng);
+		grid.setRotation(rotateOp, rotation);
+		if (rng.nextBoolean()) {
+			grid.randomReflection();
+		}
+		return grid;
+	}
+
+	/**
+	 * Maps the line to section in the interval.
+	 *
+	 * @param line an (origin, direction pair).
+	 * @param interval an interval.
+	 * @param intersectOp an op for finding the intersections of the line and the
+	 *          interval.
+	 * @return a {@link Section} in the interval, null if line doesn't intersect
+	 *         it.
+	 */
+	private static Section findSection(final ValuePair<Point3d, Vector3d> line,
+		final Interval interval,
+		final BinaryFunctionOp<ValuePair<Point3d, Vector3d>, Interval, Optional<ValuePair<DoubleType, DoubleType>>> intersectOp)
+	{
+		final Optional<ValuePair<DoubleType, DoubleType>> result = intersectOp
+			.calculate(line, interval);
+		if (!result.isPresent()) {
+			return null;
+		}
+		final ValuePair<DoubleType, DoubleType> scalars = result.get();
+		final double tMin = scalars.getA().get();
+		final double tMax = scalars.getB().get();
+		return new Section(line.a, line.b, tMin, tMax);
+	}
+
+	private static <B extends BooleanType<B>> long sampleIntercepts(
+		final RandomAccessibleInterval<B> interval, final Section section,
+		final double increment, final Random random)
+	{
+		// Add a random offset so that sampling doesn't always start from the same
+		// plane
+		final double startT = section.tMin + random.nextDouble() * increment;
+		if (startT > section.tMax) {
+			return -1;
+		}
+		final Vector3d samplePoint = new Vector3d(section.direction);
+		samplePoint.scale(startT);
+		samplePoint.add(section.origin);
+		final Vector3d gap = new Vector3d(section.direction);
+		gap.scale(increment);
+		long intercepts = 0;
+		long samples = 0;
+		final RandomAccess<B> access = interval.randomAccess();
+		boolean previous = sampleVoxel(access, samplePoint);
+		final long iterations = (long) Math.ceil((section.tMax - startT) /
+			increment);
+		for (long i = 0; i < iterations; i++) {
+			final boolean current = sampleVoxel(access, samplePoint);
+			if (current != previous) {
+				intercepts++;
+			}
+			previous = current;
+			samplePoint.add(gap);
+			samples++;
+		}
+		return samples >= 2 ? intercepts : -1;
+	}
+
+	private static <B extends BooleanType<B>> boolean sampleVoxel(
+		final RandomAccess<B> access, final Vector3d v)
+	{
+		access.setPosition((long) v.x, 0);
+		access.setPosition((long) v.y, 1);
+		access.setPosition((long) v.z, 2);
+		return access.get().get();
+	}
+
+	private static <B extends BooleanType<B>> Vector3d toMILVector(
+		final Section section, final RandomAccessibleInterval<B> interval,
+		final double increment, final Random random)
+	{
+		final long intercepts = sampleIntercepts(interval, section, increment,
+			random);
+		if (intercepts < 0) {
+			return null;
+		}
+		final Vector3d milVector = new Vector3d(section.direction);
+		if (intercepts >= 2) {
+			milVector.scale(1.0 / intercepts);
+		}
+		return milVector;
+	}
+
+	/**
+	 * Stores the origin <b>a</b> and direction <b>v</b> of a line, and the
+	 * scalars for <b>a</b> + <em>t<sub>1</sub></em><b>v</b> and <b>a</b> +
+	 * <em>t<sub>2</sub></em><b>v</b> where the line intersects an interval.
+	 */
+	private static class Section {
+
+		private final double tMin;
+		private final double tMax;
+		private final Point3d origin;
+		private final Vector3d direction;
+
+		private Section(final Point3d origin, final Vector3d direction,
+			final double tMin, final double tMax)
+		{
+			this.tMin = tMin;
+			this.tMax = tMax;
+			this.origin = new Point3d(origin);
+			this.direction = new Vector3d(direction);
+		}
+	}
+
+	// endregion
+}

--- a/Modern/ops/src/test/java/org/bonej/ops/mil/LineGridTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/mil/LineGridTest.java
@@ -151,7 +151,7 @@ public class LineGridTest {
 	@Test
 	public void testLinesNBins() throws Exception {
 		// SETUP
-		final long bins = 2;
+		final long bins = 10;
 		final long binsPerPlane = bins * bins;
 		final long expectedLines = binsPerPlane * 3;
 		final LineGrid grid = new LineGrid(img);

--- a/Modern/ops/src/test/java/org/bonej/ops/mil/MILGridTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/mil/MILGridTest.java
@@ -1,0 +1,231 @@
+
+package org.bonej.ops.mil;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+import net.imagej.ImageJ;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.scijava.vecmath.AxisAngle4d;
+import org.scijava.vecmath.Vector3d;
+
+/**
+ * Tests for {@link MILGrid}.
+ *
+ * @author Richard Domander
+ */
+public class MILGridTest {
+
+	private static final ImageJ IMAGE_J = new ImageJ();
+	private static final long SIZE = 5;
+	private static final Img<BitType> BG_IMG = ArrayImgs.bits(SIZE, SIZE, SIZE);
+	private static final long DEFAULT_BINS = SIZE;
+	private static final long EXPECTED_SIZE = 27;
+	private static final AxisAngle4d IDENTITY_ROTATION = new AxisAngle4d();
+	private static final double DEFAULT_INCREMENT = 1.0;
+
+	// Each test creates its own random generator with a constant seed. This is
+	// because called through IMAGE_J.op().run(), the ops run in different
+	// threads, thus making the tests non-deterministic if they shared a
+	// generator.
+	private final BiPredicate<Vector3d, Vector3d> isParallel = (u, v) -> {
+		final Vector3d product = new Vector3d();
+		product.cross(u, v);
+		final Vector3d zeroVector = new Vector3d(0, 0, 0);
+		return product.equals(zeroVector);
+	};
+
+	/**
+	 * Tests that changing the bins parameter changes the number of vectors
+	 * created (in comparison to {@link #testEmptyInterval()})
+	 */
+	@Test
+	public void testBinsParameter() throws Exception {
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, BG_IMG, DEFAULT_BINS + 1L, DEFAULT_INCREMENT,
+			IDENTITY_ROTATION, new Random(0xc0ff33));
+
+		assertTrue("The bins parameter had no effect", EXPECTED_SIZE < milVectors
+			.size());
+	}
+
+	/**
+	 * Tests the op on a cube. Most vectors should enter and exit it, i.e. their
+	 * length should be 0.5.
+	 */
+	@Test
+	public void testCube() throws Exception {
+		final Img<BitType> cube = ArrayImgs.bits(100, 100, 100);
+		final IntervalView<BitType> foreground = Views.interval(cube, new long[] {
+			1, 1, 1 }, new long[] { 98, 98, 98 });
+		foreground.cursor().forEachRemaining(BitType::setOne);
+		final double expectedLength = 1.0 / 2.0;
+
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, cube, 10L, DEFAULT_INCREMENT, IDENTITY_ROTATION,
+			new Random(0xc0ff33));
+
+		// Some vectors will always miss the object, so not all vectors will have
+		// length < 1.0
+		assertEquals("Regression test failed: number of vectors changed", 95,
+			milVectors.size());
+		assertEquals(
+			"Regression test failed: number of vectors that have intercepted the cube changed",
+			91, milVectors.stream().filter(v -> v.length() == expectedLength)
+				.count());
+	}
+
+	@Test
+	public void testEmptyInterval() throws Exception {
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, BG_IMG, DEFAULT_BINS, DEFAULT_INCREMENT, IDENTITY_ROTATION,
+			new Random(0xc0ff33));
+
+		assertEquals("Regression test failed: number of vectors unexpected",
+			EXPECTED_SIZE, milVectors.size());
+		assertTrue(
+			"Regression test failed: identity rotation should create vectors normal to the XY-plane",
+			milVectors.stream().anyMatch(v -> v.equals(new Vector3d(0, 0, 1))));
+		assertTrue("All vectors should have length 1.0", milVectors.stream()
+			.allMatch(v -> v.length() == 1.0));
+	}
+
+	/**
+	 * Tests that changing the increment parameter changes the number of vectors
+	 * that have a certain number of interceptions in comparison to
+	 * {@link #testXYSheets()}. The increasing the increment should move the
+	 * sample points so that most of the vectors encounter the sheets less often.
+	 */
+	@Test
+	public void testIncrementParameter() throws Exception {
+		// SETUP
+		final long numSheets = 10;
+		final Img<BitType> sheets = drawXYSheets();
+
+		// EXECUTE
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, sheets, DEFAULT_BINS, 1.1, IDENTITY_ROTATION, new Random(
+				0xc0ff33));
+
+		// VERIFY
+		final Stream<Vector3d> zVectors = milVectors.stream().filter(v -> isParallel
+			.test(v, new Vector3d(0, 0, 1)));
+		assertEquals(
+			"Regression test failed: changing the increment parameter had no effect",
+			2, zVectors.filter(v -> v.length() == 1.0 / (2 * numSheets)).count());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMatchingFailsIf2DInterval() throws Exception {
+		final Img<BitType> img = ArrayImgs.bits(5, 5);
+		IMAGE_J.op().run(MILGrid.class, img);
+	}
+
+	/**
+	 * Tests that changing the rotation parameter changes the orientation of MIL
+	 * vectors (in comparison to {@link #testEmptyInterval()})
+	 */
+	@Test
+	public void testRotationParameter() throws Exception {
+		final AxisAngle4d rotation = new AxisAngle4d(0, 1, 1, Math.PI / 4.0);
+
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, BG_IMG, DEFAULT_BINS, DEFAULT_INCREMENT, rotation,
+			new Random(0xc0ff33));
+
+		assertTrue("Changing the rotation parameter had no effect", milVectors
+			.stream().noneMatch(v -> v.equals(new Vector3d(0, 0, 1))));
+	}
+
+	/**
+	 * Tests the op with an image of xy-aligned "sheets". Vectors in z-direction
+	 * should be shorter than in x or y.
+	 */
+	@Test
+	public void testXYSheets() throws Exception {
+		// SETUP
+		final int numSheets = 10;
+		final Vector3d zAxis = new Vector3d(0, 0, 1);
+		final double expectedZLength = 1.0 / (numSheets * 2);
+		final Img<BitType> sheets = drawXYSheets();
+
+		// EXECUTE
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, sheets, DEFAULT_BINS, DEFAULT_INCREMENT, IDENTITY_ROTATION,
+			new Random(0xc0ff33));
+
+		// VERIFY
+		final Stream<Vector3d> zVectors = milVectors.stream().filter(v -> isParallel
+			.test(v, zAxis));
+		assertTrue("MIL vectors in the Z-direction have unexpected length", zVectors
+			.allMatch(v -> v.length() == expectedZLength));
+		final Stream<Vector3d> otherVectors = milVectors.stream().filter(
+			v -> !isParallel.test(v, zAxis));
+		assertTrue("All MIL vectors in X- Y-directions should have length 1.0",
+			otherVectors.allMatch(v -> v.length() == 1.0));
+	}
+
+	@Test
+	public void testXZSheets() throws Exception {
+		// SETUP
+		final Img<BitType> sheets = ArrayImgs.bits(100, 100, 100);
+		// Draw 19 XZ sheets
+		final long numSheets = 19;
+		for (long y = 5; y < 100; y += 5) {
+			final IntervalView<BitType> sheet = Views.interval(sheets, new long[] { 0,
+				y, 0 }, new long[] { 99, y, 99 });
+			sheet.cursor().forEachRemaining(BitType::setOne);
+		}
+
+		// EXECUTE
+		@SuppressWarnings("unchecked")
+		final List<Vector3d> milVectors = (List<Vector3d>) IMAGE_J.op().run(
+			MILGrid.class, sheets, DEFAULT_BINS, DEFAULT_INCREMENT, IDENTITY_ROTATION,
+			new Random(0xc0ff33));
+
+		// VERIFY
+		final Stream<Vector3d> yVectors = milVectors.stream().filter(v -> isParallel
+			.test(v, new Vector3d(0, 1, 0)));
+		assertTrue("MIL vectors in the Y-direction have unexpected length", yVectors
+			.allMatch(v -> v.length() == 1.0 / (2 * numSheets)));
+	}
+
+	@AfterClass
+	public static void oneTimeTearDown() {
+		IMAGE_J.context().dispose();
+	}
+
+	// region -- Helper methods --
+
+	private static Img<BitType> drawXYSheets() {
+		final Img<BitType> sheets = ArrayImgs.bits(100, 100, 100);
+		long z = 5;
+		for (int i = 0; i < 10; i++) {
+			final IntervalView<BitType> sheet = Views.interval(sheets, new long[] { 0,
+				0, z }, new long[] { 99, 99, z });
+			sheet.cursor().forEachRemaining(BitType::setOne);
+			z += 10;
+		}
+		return sheets;
+	}
+
+	// endregion
+}

--- a/Modern/ops/src/test/java/org/bonej/ops/mil/MILPOCDirectionComponents.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/mil/MILPOCDirectionComponents.java
@@ -1,8 +1,6 @@
 
 package org.bonej.ops.mil;
 
-// TODO Link op class to comment.
-
 import static org.bonej.ops.mil.MILPOCSampling.createGrid;
 import static org.bonej.ops.mil.MILPOCSampling.createSections;
 
@@ -38,7 +36,7 @@ import org.scijava.vecmath.Tuple3d;
 import org.scijava.vecmath.Vector3d;
 
 /**
- * Another proof-of-concept for Mean intercept length that continues where
+ * Another proof-of-concept for the {@link MILGrid} op that continues where
  * {@link MILPOCSampling} left. This one shows that an image is sampled randomly
  * from each orthogonal direction (x,y,z). Result is displayed as an image with
  * three channels: red for X, green for Y and blue for Z.

--- a/Modern/ops/src/test/java/org/bonej/ops/mil/MILPOCSampling.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/mil/MILPOCSampling.java
@@ -30,11 +30,10 @@ import org.scijava.vecmath.Point3d;
 import org.scijava.vecmath.Tuple3d;
 import org.scijava.vecmath.Vector3d;
 
-// TODO Link op class to comment.
 /**
  * A small proof-of-concept that shows that a grid of directional vectors
  * samples an image uniformly when rotated multiple times. A similar type of
- * sampling is the first step in the MeanInterceptLengths op.
+ * sampling is the first step in the {@link MILGrid} op.
  *
  * @author Richard Domander
  */


### PR DESCRIPTION
Adds an Op that samples the mean intercept length of an interval. It's used to analyse the anisotropy of an image.