### PR TITLE
Anisotropy wrapper

### DIFF
--- a/IntegrationTestLogs/Anisotropy.txt
+++ b/IntegrationTestLogs/Anisotropy.txt
@@ -1,0 +1,65 @@
+Manual integration tests for the Anisotropy command.
+
+
+Case 1
+=======================================================================
+Checking "Auto parameters" sets parameters to default values
+=======================================================================
+Steps
+-----------------------------------------------------------------------
+1. Run File > Open samples > Bat Cochlea Volume
+2. Run plugin BoneJ > Anisotropy
+3. Set the "Rotations" to 1, "Lines" to 1 and "Increment" to 10.0
+4. Check "Auto parameters"
+
+
+Expected result
+-----------------------------------------------------------------------
+All three values change when check box is ticked
+
+Completed Month Day Year Name Surname
+-----------------------------------------------------------------------
+
+
+Case 2
+=======================================================================
+Parameter values cannot be changed when "Auto parameters"
+is checked
+=======================================================================
+Steps
+-----------------------------------------------------------------------
+1. Run File > Open samples > Bat Cochlea Volume
+2. Run plugin BoneJ > Anisotropy
+3. Check "Auto parameters"
+
+Expected result
+-----------------------------------------------------------------------
+"Rotations", "Lines" and "Increment" revert to default value
+when focus leaves their corresponding widget.
+
+Completed Month Day Year Name Surname
+-----------------------------------------------------------------------
+
+
+Case 3
+=======================================================================
+Clicking "Cancel" on the anisotropic calibration warning dialog
+stops the command.
+=======================================================================
+Steps
+-----------------------------------------------------------------------
+1. Run File > Open samples > Bat Cochlea Volume
+2. Run Analyze > Set Scale
+3. Set "Distance in pixels" to "1", "Known distance" to "0.5",
+   "Pixel aspect ratio" to "1" and "Unit of length" to "mm"
+4. Run plugin BoneJ > Anisotropy
+5. Check "Auto parameters"
+6. Click "OK"
+7. Click "Cancel" on the warning dialog
+
+Expected result
+-----------------------------------------------------------------------
+Warning dialog pops open, and command stops when user cancels.
+
+Completed Month Day Year Name Surname
+-----------------------------------------------------------------------

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -1,0 +1,296 @@
+
+package org.bonej.wrapperPlugins;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.generate;
+import static org.bonej.utilities.AxisUtils.getSpatialUnit;
+import static org.bonej.utilities.Streamers.spatialAxisStream;
+import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
+import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
+import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
+import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
+import static org.scijava.ui.DialogPrompt.OptionType.OK_CANCEL_OPTION;
+import static org.scijava.ui.DialogPrompt.Result.OK_OPTION;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import net.imagej.ImgPlus;
+import net.imagej.axis.CalibratedAxis;
+import net.imagej.ops.OpService;
+import net.imagej.ops.special.function.BinaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.table.DefaultColumn;
+import net.imagej.table.Table;
+import net.imagej.units.UnitService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+
+import org.bonej.ops.SolveQuadricEq;
+import org.bonej.ops.ellipsoid.Ellipsoid;
+import org.bonej.ops.ellipsoid.QuadricToEllipsoid;
+import org.bonej.ops.mil.MILGrid;
+import org.bonej.utilities.AxisUtils;
+import org.bonej.utilities.ElementUtil;
+import org.bonej.utilities.SharedTable;
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
+import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils;
+import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
+import org.scijava.ItemIO;
+import org.scijava.ItemVisibility;
+import org.scijava.app.StatusService;
+import org.scijava.command.Command;
+import org.scijava.command.ContextCommand;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.DialogPrompt;
+import org.scijava.ui.UIService;
+import org.scijava.vecmath.AxisAngle4d;
+import org.scijava.vecmath.Matrix4d;
+import org.scijava.vecmath.Vector3d;
+import org.scijava.widget.NumberWidget;
+
+/**
+ * A command that analyses the degree of anisotropy in an image.
+ *
+ * @author Richard Domander
+ */
+@Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Anisotropy")
+public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
+	ContextCommand
+{
+
+	private static BinaryFunctionOp<RandomAccessibleInterval<BitType>, AxisAngle4d, List<Vector3d>> milOp;
+	private static UnaryFunctionOp<Matrix4d, Optional<Ellipsoid>> quadricToEllipsoidOp;
+	private static UnaryFunctionOp<List<Vector3d>, Matrix4d> solveQuadricOp;
+	private static int ROTATIONS = 1_000;
+	private static int DEFAULT_LINES = 50;
+	private static double DEFAULT_INCREMENT = 1.0;
+	/** Assumes that the longest radius of the ellipsoid is 1.0 */
+	private final Function<Ellipsoid, Double> degreeOfAnisotropy =
+		ellipsoid -> 1.0 - ellipsoid.getA() / ellipsoid.getC();
+	@SuppressWarnings("unused")
+	@Parameter(validater = "validateImage")
+	private ImgPlus<T> inputImage;
+	@Parameter(label = "Auto parameters", required = false, persist = false,
+		callback = "setAutoParam")
+	private boolean autoParameters = false;
+	@Parameter(label = "Rotations",
+		description = "The number of times sampling is performed from different directions",
+		min = "1", style = NumberWidget.SPINNER_STYLE, required = false,
+		callback = "setAutoParam")
+	private Integer rotations = ROTATIONS;
+	@Parameter(label = "Sampling lines",
+		description = "Number of sampling lines drawn. The number is squared and multiplied by three",
+		min = "1", style = NumberWidget.SPINNER_STYLE, required = false,
+		callback = "setAutoParam")
+	private Integer lines = DEFAULT_LINES;
+	@Parameter(label = "Sampling increment", min = "0.01",
+		description = "Distance between sampling points (in pixels)",
+		style = NumberWidget.SPINNER_STYLE, required = false,
+		callback = "setAutoParam", stepSize = "0.1")
+	private Double samplingIncrement = DEFAULT_INCREMENT;
+	@Parameter(visibility = ItemVisibility.MESSAGE)
+	private String instruction =
+		"NB parameter values can affect results significantly";
+
+	// TODO add @Parameter to print eigenvectors & -values of the ellipsoid
+
+	// TODO add @Parameter to align the image to the ellipsoid
+	// Create a rotated view from the ImgPlus and pop that into an output
+	// @Parameter
+
+	// TODO add help button
+	@Parameter(visibility = ItemVisibility.MESSAGE)
+	private String divider = "- - -";
+	/**
+	 * The anisotropy results in a {@link Table}.
+	 * <p>
+	 * Null if there are no results.
+	 * </p>
+	 */
+	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
+	private Table<DefaultColumn<String>, String> resultsTable;
+	@Parameter
+	private LogService logService;
+	@Parameter
+	private StatusService statusService;
+	@Parameter
+	private OpService opService;
+	@Parameter
+	private UIService uiService;
+	@Parameter
+	private UnitService unitService;
+
+	@Override
+	public void run() {
+		statusService.showStatus("Anisotropy: initialising");
+		final ImgPlus<BitType> bitImgPlus = Common.toBitTypeImgPlus(opService,
+			inputImage);
+		final List<Subspace<BitType>> subspaces = HyperstackUtils.split3DSubspaces(
+			bitImgPlus).collect(toList());
+		matchOps(subspaces.get(0));
+		// TODO Does it make more sense to collect all the results we can (without
+		// cancelling) and then report errors at the end?
+		for (int i = 0; i < subspaces.size(); i++) {
+			final Subspace<BitType> subspace = subspaces.get(i);
+			statusService.showStatus("Anisotropy: sampling subspace #" + (i + 1));
+			Ellipsoid ellipsoid;
+			try {
+				final List<Vector3d> pointCloud = runRotationsInParallel(
+					subspace.interval);
+				applyCalibration(pointCloud);
+				ellipsoid = fitEllipsoid(pointCloud);
+			}
+			catch (ExecutionException | InterruptedException e) {
+				logService.trace(e.getMessage());
+				cancel("Parallel execution got interrupted");
+				return;
+			}
+			if (ellipsoid == null) {
+				cancel(
+					"Anisotropy could not be calculated - try adding more rotations");
+				return;
+			}
+			final double anisotropy = degreeOfAnisotropy.apply(ellipsoid);
+			addResult(subspace, anisotropy);
+		}
+		if (SharedTable.hasData()) {
+			resultsTable = SharedTable.getTable();
+		}
+	}
+
+	// region -- Helper methods --
+
+	private void addResult(final Subspace<BitType> subspace,
+		final double anisotropy)
+	{
+		final String imageName = inputImage.getName();
+		final String suffix = subspace.toString();
+		final String label = suffix.isEmpty() ? imageName : imageName + " " +
+			suffix;
+		SharedTable.add(label, "Degree of anisotropy", anisotropy);
+	}
+
+	private void applyCalibration(final List<Vector3d> pointCloud) {
+		final double[] scales = spatialAxisStream(inputImage).mapToDouble(
+			axis -> axis.averageScale(0, 1)).toArray();
+		final String[] units = spatialAxisStream(inputImage).map(
+			CalibratedAxis::unit).toArray(String[]::new);
+		final double yxConversion = unitService.value(1.0, units[1], units[0]);
+		final double zxConversion = unitService.value(1.0, units[2], units[0]);
+		final double xScale = scales[0];
+		final double yScale = scales[1] * yxConversion;
+		final double zScale = scales[2] * zxConversion;
+		pointCloud.forEach(p -> {
+			p.setX(p.x * xScale);
+			p.setY(p.y * yScale);
+			p.setZ(p.z * zScale);
+		});
+	}
+
+	private Ellipsoid fitEllipsoid(final List<Vector3d> pointCloud) {
+		if (pointCloud.size() < SolveQuadricEq.QUADRIC_TERMS) {
+			return null;
+		}
+
+		final Matrix4d quadric = solveQuadricOp.calculate(pointCloud);
+		final Optional<Ellipsoid> result = quadricToEllipsoidOp.calculate(quadric);
+		return result.orElse(null);
+	}
+
+	//TODO Refactor into a static utility method with unit tests
+	private boolean isCalibrationIsotropic() {
+		final Optional<String> commonUnit = getSpatialUnit(inputImage, unitService);
+		if (!commonUnit.isPresent()) {
+			return false;
+		}
+		final String unit = commonUnit.get();
+		return spatialAxisStream(inputImage).map(axis -> unitService.value(axis
+			.averageScale(0, 1), axis.unit(), unit)).distinct().count() == 1;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void matchOps(final Subspace<BitType> subspace) {
+		milOp = (BinaryFunctionOp) Functions.binary(opService, MILGrid.class,
+			List.class, subspace.interval, new AxisAngle4d(), lines,
+			samplingIncrement, new Random());
+		final List<Vector3d> tmpPoints = generate(Vector3d::new).limit(
+			SolveQuadricEq.QUADRIC_TERMS).collect(toList());
+		solveQuadricOp = Functions.unary(opService, SolveQuadricEq.class,
+			Matrix4d.class, tmpPoints);
+		quadricToEllipsoidOp = (UnaryFunctionOp) Functions.unary(opService,
+			QuadricToEllipsoid.class, Optional.class, Matrix4d.class);
+	}
+
+	private List<Vector3d> runRotationsInParallel(
+		final RandomAccessibleInterval<BitType> interval) throws ExecutionException,
+		InterruptedException
+	{
+		final ExecutorService executor = Executors.newFixedThreadPool(5);
+		final Callable<List<Vector3d>> milTask = () -> milOp.calculate(interval);
+		final List<Future<List<Vector3d>>> futures = Stream.generate(() -> milTask)
+			.limit(rotations).map(executor::submit).collect(toList());
+		final List<Vector3d> pointCloud = Collections.synchronizedList(
+			new ArrayList<>(rotations * 3));
+		final int futuresSize = futures.size();
+		for (int j = 0; j < futuresSize; j++) {
+			statusService.showProgress(j, futuresSize);
+			final List<Vector3d> points = futures.get(j).get();
+			pointCloud.addAll(points);
+
+		}
+		executor.shutdown();
+		return pointCloud;
+	}
+
+	@SuppressWarnings("unused")
+	private void setAutoParam() {
+		if (!autoParameters) {
+			return;
+		}
+		rotations = ROTATIONS;
+		lines = DEFAULT_LINES;
+		samplingIncrement = DEFAULT_INCREMENT;
+	}
+
+	@SuppressWarnings("unused")
+	private void validateImage() {
+		if (inputImage == null) {
+			cancel(NO_IMAGE_OPEN);
+			return;
+		}
+		if (AxisUtils.countSpatialDimensions(inputImage) != 3) {
+			cancel(NOT_3D_IMAGE);
+			return;
+		}
+		if (!ElementUtil.isColorsBinary(inputImage)) {
+			cancel(NOT_BINARY);
+			return;
+		}
+		if (!isCalibrationIsotropic()) {
+			final DialogPrompt.Result result = uiService.showDialog(
+				"The image calibration is anisotropic and may affect results. Continue anyway?",
+				WARNING_MESSAGE, OK_CANCEL_OPTION);
+			if (result != OK_OPTION) {
+				cancel(null);
+			}
+		}
+		// TODO Is the 5 slice minimum necessary?
+	}
+	// endregion
+}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -1,0 +1,106 @@
+
+package org.bonej.wrapperPlugins;
+
+import static org.junit.Assert.assertFalse;
+
+import net.imagej.ImageJ;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.DefaultLinearAxis;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.view.Views;
+
+import org.junit.AfterClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.scijava.command.CommandModule;
+
+/**
+ * Tests for {@link AnisotropyWrapper}.
+ *
+ * @author Richard Domander
+ */
+// TODO Complete tests when implementation stabilises
+@Ignore
+@Category(SlowWrapperTest.class)
+public class AnisotropyWrapperTest {
+
+	private static final ImageJ IMAGE_J = new ImageJ();
+
+	@Test
+	public void test2DImageCancelsWrapper() throws Exception {
+		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
+			AnisotropyWrapper.class);
+	}
+
+	@Test
+	public void testAnisotropicCalibrationShowsWarningDialog() throws Exception {
+
+	}
+
+	@Test
+	public void testCalibrationAffectsResults() throws Exception {
+
+	}
+
+	// TODO How to test this?
+	@Test
+	public void testEllipsoidFittingFailingCancelsPlugins() throws Exception {
+
+	}
+
+	@Test
+	public void testHyperStackResultsTable() throws Exception {
+		// SETUP
+		final String unit = "mm";
+		final double scale = 1.0;
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, unit, scale);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, unit, scale);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, unit, scale);
+		final DefaultLinearAxis cAxis = new DefaultLinearAxis(Axes.CHANNEL);
+		final DefaultLinearAxis tAxis = new DefaultLinearAxis(Axes.TIME);
+		final Img<BitType> img = ArrayImgs.bits(100, 100, 100, 2, 2);
+		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
+			yAxis, zAxis, cAxis, tAxis);
+		// TODO draw sheets
+		// Draw cubes to subspaces (channel 0, time 0) and (channel 1, time 1)
+		Views.interval(imgPlus, new long[] { 1, 1, 1, 0, 0 }, new long[] { 98, 98,
+			98, 0, 0 }).forEach(BitType::setOne);
+		Views.interval(imgPlus, new long[] { 1, 1, 1, 1, 1 }, new long[] { 98, 98,
+			98, 1, 1 }).forEach(BitType::setOne);
+
+		// EXECUTE
+		final CommandModule module = IMAGE_J.command().run(AnisotropyWrapper.class,
+			true, "inputImage", imgPlus, "rotations", 100).get();
+
+		// VERIFY
+		assertFalse(module.isCanceled());
+		// TODO assert that results in two subspaces are different than the two
+		// other
+	}
+
+	@Test
+	public void testNonBinaryImageCancelsWrapper() throws Exception {
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+			AnisotropyWrapper.class);
+	}
+
+	@Test
+	public void testNullImageCancelsWrapper() throws Exception {
+		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+			AnisotropyWrapper.class);
+	}
+
+	@Test
+	public void testTooFewPointsCancelsPlugin() throws Exception {
+
+	}
+
+	@AfterClass
+	public static void oneTimeTearDown() {
+		IMAGE_J.context().dispose();
+	}
+}


### PR DESCRIPTION
When coding this branch, I realised that the `MILGrid` op and ellipsoid fitting didn't fit together. They didn't produce stable results within small tolerance, and input parameter values affected the result too much. This pull request creates a prototype Anisotropy command, that uses a modified MILGrid op. 

The modified MILGrid returns the three shortest MIL vectors it sampled on the image. In the command the op is repeated n times and then it tries to fit an ellipsoid on the point cloud that results from these calls. The results change less from run to run than in BoneJ1, and seem intuitive: a cube is very isotropic, a stack of "sheets" parallel to the xy-plane is anisotropic, and "Bat cochlea volume" is somewhere in between.

* Refactors the `LineGrid` class
* Refactors the `MILGrid` class
* Adds `Anisotropy` command
* Adds some tests for the command, and notes on what still needs to be done.