### PR TITLE
DistanceFromEllipsoidSurfaceOp

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOp.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOp.java
@@ -5,10 +5,7 @@ import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
 import net.imglib2.type.numeric.real.DoubleType;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.vecmath.Matrix4d;
-import org.scijava.vecmath.Point3d;
-import org.scijava.vecmath.Vector2d;
-import org.scijava.vecmath.Vector3d;
+import org.scijava.vecmath.*;
 
 /**
  * An Op that calculates the distance between a point and an ellipsoid surface
@@ -16,30 +13,43 @@ import org.scijava.vecmath.Vector3d;
  * Uses a hard-coded bivariate Newton-Raphson solver to efficiently find values of theta and phi that solve
  * the orthogonality condition F(theta,phi)=0 for the vector between the surface and the point.
  * Then converts into Cartesian coordinates to calculate the distance. Derivation of required terms courtesy
- * of Robert Nürnberg, Imperial College London (http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf).
+ * of Robert Nürnberg, Imperial College London (See <a href="http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf">http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf</a>).
+ * Works for three-dimensional case only.
  * </p>
  *
  * @author Alessandro Felder
  */
 
-@Plugin(name = "Distance from Point to Ellipsoid Surface", type = Op.class)
-public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ellipsoid, Point3d, DoubleType>
-{
 
+@Plugin(name = "Distance from Point to Ellipsoid Surface", type = Op.class)
+public class DistanceFromEllipsoidSurfaceOp<T extends Tuple3d> extends AbstractBinaryFunctionOp<Ellipsoid, T, DoubleType>
+{
+    /**
+     * tolerance below which the Newton-Raphson solver considers the current solution converged
+     */
     @Parameter(required = false, persist = false)
     private double tolerance = 1.0e-12;
 
+    /**
+     * maximum number of iterations performed by Newton-Raphson solver
+     */
     @Parameter(required = false, persist = false)
     private long maxIterations = 100;
 
+    /**
+     * Calculates the shortest distance between a point and the surface of an ellipsoid
+     * @param ellipsoid the ellipsoid in question
+     * @param point the point in question
+     * @return shortest distance
+     */
     @Override
-    public DoubleType calculate(final Ellipsoid ellipsoid, final Point3d point) {
+    public DoubleType calculate(final Ellipsoid ellipsoid, final T point) {
 
         double a = ellipsoid.getA();
         double b = ellipsoid.getB();
         double c = ellipsoid.getC();
 
-        Point3d pointInEllipsoidCoordinates = ToEllipsoidCoordinates(point,ellipsoid);
+        Point3d pointInEllipsoidCoordinates = toEllipsoidCoordinates(point,ellipsoid);
         
         double rootTerm = Math.sqrt(pointInEllipsoidCoordinates.x*pointInEllipsoidCoordinates.x/(a*a)+pointInEllipsoidCoordinates.y*pointInEllipsoidCoordinates.y/(b*b));
         Vector2d anglesK = new Vector2d(Math.atan2(a*pointInEllipsoidCoordinates.y,b*pointInEllipsoidCoordinates.x),Math.atan2(pointInEllipsoidCoordinates.z, c*rootTerm));
@@ -48,31 +58,49 @@ public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ell
         while(iterations<maxIterations)
         {
             anglesKPlus1 = new Vector2d(anglesK.x, anglesK.y);
-            anglesKPlus1.add(DFInverseTimesF(anglesK,ellipsoid,pointInEllipsoidCoordinates));
-            if(getDifference(anglesK, anglesKPlus1)<tolerance) break;
+            anglesKPlus1.add(dFInverseTimesF(anglesK,ellipsoid,pointInEllipsoidCoordinates));
+
+            if(getDifference(anglesK, anglesKPlus1)<tolerance)
+            {
+                break;
+            }
 
             anglesK = new Vector2d(anglesKPlus1.x, anglesKPlus1.y);
             iterations++;
         }
 
-        Vector3d closestPointOnEllipsoidSurface = getCartesianCoordinates(anglesKPlus1,ellipsoid);
+        Vector3d closestPointOnEllipsoidSurface = getCartesianCoordinatesFromAngleParametrization(anglesKPlus1,ellipsoid);
         closestPointOnEllipsoidSurface.scaleAdd(-1.0,pointInEllipsoidCoordinates);
         return new DoubleType(closestPointOnEllipsoidSurface.length());
     }
 
-    static Point3d ToEllipsoidCoordinates(final Point3d point, final Ellipsoid ellipsoid) {
+    /**
+     * Perform appropriate transformations on point to find its representation relative to ellipsoid centre and orientation.
+     * @param point point to transform
+     * @param ellipsoid ellipsoid determining coordinates
+     * @return point in ellipsoid coordinates
+     */
+    static Point3d toEllipsoidCoordinates (final Tuple3d point, final Ellipsoid ellipsoid)  {
         Point3d translated = new Point3d(ellipsoid.getCentroid());
         translated.scale(-1.0);
         translated.add(point);
-        Point3d rotated = new Point3d(0,0,0);
+
         Matrix4d orientation = ellipsoid.getOrientation();
-        rotated.x = orientation.m00*translated.x+ orientation.m10*translated.y+orientation.m20*translated.z;
-        rotated.y = orientation.m01*translated.x+ orientation.m11*translated.y+orientation.m21*translated.z;
-        rotated.z = orientation.m02*translated.x+ orientation.m12*translated.y+orientation.m22*translated.z;
-        return rotated;
+        final double x = orientation.m00*translated.x+ orientation.m10*translated.y+orientation.m20*translated.z;
+        final double y = orientation.m01*translated.x+ orientation.m11*translated.y+orientation.m21*translated.z;
+        final double z = orientation.m02*translated.x+ orientation.m12*translated.y+orientation.m22*translated.z;
+        return new Point3d(x, y, z);
     }
 
-    private static Vector3d getCartesianCoordinates(final Vector2d angles, final Ellipsoid ellipsoid) {
+    /**
+     * Get the 3D vector x(theta, phi) on the ellipsoid surface from the angle parameters (theta, phi).
+     * The ellipsoid surface is parametrized by (a*cos(phi)*cos(theta), b*cos(phi)*sin(theta), ),
+     * where a,b,c are the semi-axis lengths.
+     * @param angles a 2D vector containing (theta,phi)
+     * @param ellipsoid the ellipsoid
+     * @return x(theta,phi)
+     */
+    private static Vector3d getCartesianCoordinatesFromAngleParametrization(final Vector2d angles, final Ellipsoid ellipsoid) {
         double theta = angles.x;
         double phi = angles.y;
 
@@ -83,7 +111,14 @@ public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ell
         return new Vector3d(x,y,z);
     }
 
-    static private Vector2d DFInverseTimesF(final Vector2d angles, final Ellipsoid ellipsoid, final Point3d point) {
+    /**
+     * Calculates the inverse Jacobian matrix DF^{-1} multiplied by F(angles) - details in (See <a href="http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf">http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf</a>)
+     * @param angles current estimate for ellipsoid surface angular parameters
+     * @param ellipsoid ellipsoid to which the closest distance should be found
+     * @param point point for which the closest distance to the ellipsoid surface should be found
+     * @return inverse Jacobian matrix DF^{-1} times F(angles)
+     */
+    static private Vector2d dFInverseTimesF(final Vector2d angles, final Ellipsoid ellipsoid, final Point3d point) {
         double a = ellipsoid.getA();
         double b = ellipsoid.getB();
         double c = ellipsoid.getC();
@@ -94,22 +129,22 @@ public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ell
         double z = point.z;
 
         double theta = angles.x;
-        double sinTh = Math.sin(theta);
-        double sin2Th = sinTh*sinTh;
-        double cosTh = Math.cos(theta);
-        double cos2Th = cosTh*cosTh;
+        double sinTheta = Math.sin(theta);
+        double sinThetaSq = sinTheta*sinTheta;
+        double cosTheta = Math.cos(theta);
+        double cosThetaSq = cosTheta*cosTheta;
 
         double phi = angles.y;
-        double sinPh = Math.sin(phi);
-        double cosPh = Math.cos(phi);
+        double sinPhi = Math.sin(phi);
+        double cosPhi = Math.cos(phi);
 
-        double a11 = a2mb2*(cos2Th-sin2Th)*cosPh-x*a*cosTh-y*b*sinTh;
-        double a12 = -a2mb2*cosTh*sinTh*sinPh;
-        double a21 = -2.0*a2mb2*cosTh*sinTh*sinPh*cosPh+x*a*sinPh*sinTh-y*b*sinPh*cosTh;
-        double a22 = (a*a*cos2Th+b*b*sin2Th-c*c)*(cos2Th-sin2Th)-x*a*cosPh*cosTh-y*b*cosPh*sinTh-z*c*sinPh;
+        double a11 = a2mb2*(cosThetaSq-sinThetaSq)*cosPhi-x*a*cosTheta-y*b*sinTheta;
+        double a12 = -a2mb2*cosTheta*sinTheta*sinPhi;
+        double a21 = -2.0*a2mb2*cosTheta*sinTheta*sinPhi*cosPhi+x*a*sinPhi*sinTheta-y*b*sinPhi*cosTheta;
+        double a22 = (a*a*cosThetaSq+b*b*sinThetaSq-c*c)*(cosThetaSq-sinThetaSq)-x*a*cosPhi*cosTheta-y*b*cosPhi*sinTheta-z*c*sinPhi;
 
-        double f1 = a2mb2*cosTh*sinTh*cosPh-x*a*sinTh+y*b*cosTh;
-        double f2 = (a*a*cos2Th+b*b*sin2Th-c*c)*sinPh*cosPh-x*a*sinPh*cosTh-y*b*sinPh*sinTh+z*c*cosPh;
+        double f1 = a2mb2*cosTheta*sinTheta*cosPhi-x*a*sinTheta+y*b*cosTheta;
+        double f2 = (a*a*cosThetaSq+b*b*sinThetaSq-c*c)*sinPhi*cosPhi-x*a*sinPhi*cosTheta-y*b*sinPhi*sinTheta+z*c*cosPhi;
 
         double out1 = a22*f1-a12*f2;
         double out2 = -a21*f1+a11*f2;
@@ -123,8 +158,9 @@ public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ell
         return new Vector2d(out1/determinant, out2/determinant);
     }
 
-    static private double getDifference(final Vector2d angles1, final Vector2d angles2) {
-        Vector2d difference = new Vector2d(angles1.x-angles2.x, angles1.y-angles2.y);
+    private static double getDifference(final Vector2d angles1, final Vector2d angles2) {
+        Vector2d difference = new Vector2d(angles1);
+        difference.sub(angles2);
         return difference.length();
     }
 }

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOp.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOp.java
@@ -1,0 +1,131 @@
+package org.bonej.ops.ellipsoid;
+
+import net.imagej.ops.Op;
+import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
+import net.imglib2.type.numeric.real.DoubleType;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.vecmath.Matrix4d;
+import org.scijava.vecmath.Point3d;
+import org.scijava.vecmath.Vector2d;
+import org.scijava.vecmath.Vector3d;
+
+/**
+ * An Op that calculates the distance between a point and an ellipsoid surface
+ * <p>
+ * Uses a hard-coded bivariate Newton-Raphson solver to efficiently find values of theta and phi that solve
+ * the orthogonality condition F(theta,phi)=0 for the vector between the surface and the point.
+ * Then converts into Cartesian coordinates to calculate the distance. Derivation of required terms courtesy
+ * of Robert Nürnberg, Imperial College London (http://wwwf.imperial.ac.uk/~rn/distance2ellipse.pdf).
+ * </p>
+ *
+ * @author Alessandro Felder
+ */
+
+@Plugin(name = "Distance from Point to Ellipsoid Surface", type = Op.class)
+public class DistanceFromEllipsoidSurfaceOp extends AbstractBinaryFunctionOp<Ellipsoid, Point3d, DoubleType>
+{
+
+    @Parameter(required = false, persist = false)
+    private double tolerance = 1.0e-12;
+
+    @Parameter(required = false, persist = false)
+    private long maxIterations = 100;
+
+    @Override
+    public DoubleType calculate(final Ellipsoid ellipsoid, final Point3d point) {
+
+        double a = ellipsoid.getA();
+        double b = ellipsoid.getB();
+        double c = ellipsoid.getC();
+
+        Point3d pointInEllipsoidCoordinates = ToEllipsoidCoordinates(point,ellipsoid);
+        
+        double rootTerm = Math.sqrt(pointInEllipsoidCoordinates.x*pointInEllipsoidCoordinates.x/(a*a)+pointInEllipsoidCoordinates.y*pointInEllipsoidCoordinates.y/(b*b));
+        Vector2d anglesK = new Vector2d(Math.atan2(a*pointInEllipsoidCoordinates.y,b*pointInEllipsoidCoordinates.x),Math.atan2(pointInEllipsoidCoordinates.z, c*rootTerm));
+        Vector2d anglesKPlus1 = new Vector2d(0.0,0.0);
+        long iterations = 0;
+        while(iterations<maxIterations)
+        {
+            anglesKPlus1 = new Vector2d(anglesK.x, anglesK.y);
+            anglesKPlus1.add(DFInverseTimesF(anglesK,ellipsoid,pointInEllipsoidCoordinates));
+            if(getDifference(anglesK, anglesKPlus1)<tolerance) break;
+
+            anglesK = new Vector2d(anglesKPlus1.x, anglesKPlus1.y);
+            iterations++;
+        }
+
+        Vector3d closestPointOnEllipsoidSurface = getCartesianCoordinates(anglesKPlus1,ellipsoid);
+        closestPointOnEllipsoidSurface.scaleAdd(-1.0,pointInEllipsoidCoordinates);
+        return new DoubleType(closestPointOnEllipsoidSurface.length());
+    }
+
+    static Point3d ToEllipsoidCoordinates(final Point3d point, final Ellipsoid ellipsoid) {
+        Point3d translated = new Point3d(ellipsoid.getCentroid());
+        translated.scale(-1.0);
+        translated.add(point);
+        Point3d rotated = new Point3d(0,0,0);
+        Matrix4d orientation = ellipsoid.getOrientation();
+        rotated.x = orientation.m00*translated.x+ orientation.m10*translated.y+orientation.m20*translated.z;
+        rotated.y = orientation.m01*translated.x+ orientation.m11*translated.y+orientation.m21*translated.z;
+        rotated.z = orientation.m02*translated.x+ orientation.m12*translated.y+orientation.m22*translated.z;
+        return rotated;
+    }
+
+    private static Vector3d getCartesianCoordinates(final Vector2d angles, final Ellipsoid ellipsoid) {
+        double theta = angles.x;
+        double phi = angles.y;
+
+        double x = ellipsoid.getA()*Math.cos(phi)*Math.cos(theta);
+        double y = ellipsoid.getB()*Math.cos(phi)*Math.sin(theta);
+        double z = ellipsoid.getC()*Math.sin(phi);
+
+        return new Vector3d(x,y,z);
+    }
+
+    static private Vector2d DFInverseTimesF(final Vector2d angles, final Ellipsoid ellipsoid, final Point3d point) {
+        double a = ellipsoid.getA();
+        double b = ellipsoid.getB();
+        double c = ellipsoid.getC();
+        double a2mb2 = (a*a-b*b);
+
+        double x = point.x;
+        double y = point.y;
+        double z = point.z;
+
+        double theta = angles.x;
+        double sinTh = Math.sin(theta);
+        double sin2Th = sinTh*sinTh;
+        double cosTh = Math.cos(theta);
+        double cos2Th = cosTh*cosTh;
+
+        double phi = angles.y;
+        double sinPh = Math.sin(phi);
+        double cosPh = Math.cos(phi);
+
+        double a11 = a2mb2*(cos2Th-sin2Th)*cosPh-x*a*cosTh-y*b*sinTh;
+        double a12 = -a2mb2*cosTh*sinTh*sinPh;
+        double a21 = -2.0*a2mb2*cosTh*sinTh*sinPh*cosPh+x*a*sinPh*sinTh-y*b*sinPh*cosTh;
+        double a22 = (a*a*cos2Th+b*b*sin2Th-c*c)*(cos2Th-sin2Th)-x*a*cosPh*cosTh-y*b*cosPh*sinTh-z*c*sinPh;
+
+        double f1 = a2mb2*cosTh*sinTh*cosPh-x*a*sinTh+y*b*cosTh;
+        double f2 = (a*a*cos2Th+b*b*sin2Th-c*c)*sinPh*cosPh-x*a*sinPh*cosTh-y*b*sinPh*sinTh+z*c*cosPh;
+
+        double out1 = a22*f1-a12*f2;
+        double out2 = -a21*f1+a11*f2;
+        
+        double determinant = a11*a22-a12*a21;
+
+        if(determinant==0.0)
+        {
+            throw new ArithmeticException("Solution is not unique.");
+        }
+        return new Vector2d(out1/determinant, out2/determinant);
+    }
+
+    static private double getDifference(final Vector2d angles1, final Vector2d angles2) {
+        Vector2d difference = new Vector2d(angles1.x-angles2.x, angles1.y-angles2.y);
+        return difference.length();
+    }
+}
+

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOpTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOpTest.java
@@ -27,82 +27,114 @@ public class DistanceFromEllipsoidSurfaceOpTest {
 
     private static final ImageJ IMAGE_J = new ImageJ();
     private static BinaryFunctionOp<Ellipsoid, Point3d, DoubleType> distanceFromEllipsoidSurfaceOp;
+
     private static UnitSphereRandomVectorGenerator sphereRng = new UnitSphereRandomVectorGenerator(3);
+    final private Supplier<Vector3d> spherePointSupplier = () -> new Vector3d(sphereRng.nextVector());
+
+    private static Ellipsoid axisAlignedEllipsoid;
+    private static Ellipsoid transformedEllipsoid;
+    private static Ellipsoid sphere;
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         distanceFromEllipsoidSurfaceOp = Functions.binary(IMAGE_J.op(), DistanceFromEllipsoidSurfaceOp.class, DoubleType.class, Ellipsoid.class, Point3d.class);
     }
 
-    @Test
-    public void testDistanceOnAxesForAxisAlignedEllipsoid(){
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        axisAlignedEllipsoid = new Ellipsoid(1.0, 2.0, 3.0);
 
-        Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+        //axisAlignedEllipsoid translated by (1,1,1) and rotated 30 degrees around x-axis
+        transformedEllipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+        transformedEllipsoid.setOrientation(new Matrix3d(1,0,0,0,Math.sqrt(3.0)/2.0,0.5,0,-0.5,Math.sqrt(3.0)/2.0));
+        transformedEllipsoid.setCentroid(new Vector3d(1,1,1));
 
-        Point3d outsidePoint  = new Point3d(2.0,0.0,0.0);
-        Point3d insidePoint  = new Point3d(0.0,1.0,0.0);
-        Point3d surfacePoint  = new Point3d(0.0,0.0,3.0);
-
-        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
-        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
-        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
-
-        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
-        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
-        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
-
+        sphere = new Ellipsoid(2.0, 2.0, 2.0);
     }
 
-    //Ellipsoid and points from previous test translated by (1,1,1) and rotated 30 degrees around x-axis
+    /**
+     * test known distances from surface of an axis-aligned ellipsoid
+     */
     @Test
-    public void testDistanceOnAxesForArbitraryEllipsoid(){
+    public void testInsidePointForAxisAlignedEllipsoid() {
+        Point3d insidePoint = new Point3d(0.0, 1.0, 0.0);
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(axisAlignedEllipsoid, insidePoint).get();
+        assertEquals("Distance to inside point failed", 1.0, distanceToInsidePoint, 1.0e-12);
+    }
 
-        Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
-        ellipsoid.setOrientation(new Matrix3d(1,0,0,0,Math.sqrt(3.0)/2.0,0.5,0,-0.5,Math.sqrt(3.0)/2.0));
-        ellipsoid.setCentroid(new Vector3d(1,1,1));
+    @Test
+    public void testOutsidePointForAxisAlignedEllipsoid() {
+        Point3d outsidePoint = new Point3d(2.0, 0.0, 0.0);
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(axisAlignedEllipsoid, outsidePoint).get();
+        assertEquals("Distance to outside point failed", 1.0, distanceToOutsidePoint, 1.0e-12);
+    }
 
-        Point3d outsidePoint  = new Point3d(1.0+2.0,1.0,1.0);
-        Point3d insidePoint  = new Point3d(1.0,1.0+Math.sqrt(3.0)/2.0,1-0.5);
-        Point3d surfacePoint  = new Point3d(1.0,1.0+1.5,1.0+3.0*Math.sqrt(3.0)/2.0);
-
-        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
-        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
-        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
-
-        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
-        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
+    @Test
+    public void testSurfacePointForAxisAlignedEllipsoid() {
+        Point3d surfacePoint  = new Point3d(0.0,0.0,3.0);
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(axisAlignedEllipsoid,surfacePoint).get();
         assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
+    }
 
+    /**
+     * Same three tests for a more complicated ellipsoid
+     */
+    @Test
+    public void testInsidePointForArbitraryEllipsoid() {
+        Point3d insidePoint  = new Point3d(1.0,1.0+Math.sqrt(3.0)/2.0,1-0.5);
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(transformedEllipsoid, insidePoint).get();
+        assertEquals("Distance to inside point failed", 1.0, distanceToInsidePoint, 1.0e-12);
+    }
+
+    @Test
+    public void testOutsidePointForArbitraryEllipsoid() {
+        Point3d outsidePoint  = new Point3d(1.0+2.0,1.0,1.0);
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(transformedEllipsoid, outsidePoint).get();
+        assertEquals("Distance to outside point failed", 1.0, distanceToOutsidePoint, 1.0e-12);
+    }
+
+    @Test
+    public void testSurfacePointForArbitraryEllipsoid() {
+        Point3d surfacePoint  = new Point3d(1.0,1.0+1.5,1.0+3.0*Math.sqrt(3.0)/2.0);
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(transformedEllipsoid,surfacePoint).get();
+        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
+    }
+
+    /**
+     * Same three tests for a sphere and arbitrarily chosen points
+     */
+    @Test
+    public void testInsidePointForSphere() {
+        Vector3d sphereVector = new Vector3d(spherePointSupplier.get());
+        Point3d insidePoint  = new Point3d(sphereVector);
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(sphere, insidePoint).get();
+        assertEquals("Distance to inside point failed", 1.0, distanceToInsidePoint, 1.0e-12);
+    }
+
+    @Test
+    public void testOutsidePointForSphere() {
+        Vector3d sphereVector = new Vector3d(spherePointSupplier.get());
+        sphereVector.scale(3.0);
+        Point3d outsidePoint  = new Point3d(sphereVector);
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(sphere, outsidePoint).get();
+        assertEquals("Distance to outside point failed", 1.0, distanceToOutsidePoint, 1.0e-12);
+    }
+
+    @Test
+    public void testSurfacePointForSphere() {
+        Vector3d sphereVector = new Vector3d(spherePointSupplier.get());
+        sphereVector.scale(2.0);
+        Point3d surfacePoint  = new Point3d(sphereVector);
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(sphere,surfacePoint).get();
+        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
     }
 
     @Test(expected = ArithmeticException.class)
-    public void testDistanceOriginToUnitSphere() throws Exception
+    public void testArithmeticExceptionForZeroDeterminant() throws Exception
     {
         Ellipsoid ellipsoid = new Ellipsoid(2.0, 2.0, 2.0);
         Point3d origin = new Point3d(0.0,0.0,0.0);
         distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,origin).get();
-    }
-
-    @Test
-    public void testRandomPointsFromSphere()
-    {
-        final Supplier<Vector3d> spherePointSupplier = () -> new Vector3d(sphereRng.nextVector());
-        Vector3d sphereVector = new Vector3d(spherePointSupplier.get());
-        Ellipsoid ellipsoid = new Ellipsoid(2.0, 2.0, 2.0);
-
-        Point3d insidePoint  = new Point3d(sphereVector);
-        sphereVector.scale(2.0);
-        Point3d surfacePoint  = new Point3d(sphereVector);
-        sphereVector.scale(3.0/2.0);
-        Point3d outsidePoint  = new Point3d(sphereVector);
-
-        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
-        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
-        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
-
-        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
-        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
-        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
     }
 
     @Test
@@ -112,7 +144,7 @@ public class DistanceFromEllipsoidSurfaceOpTest {
         ellipsoid.setCentroid(new Vector3d(5,7,8));
         Point3d point  = new Point3d(5,7,9);
 
-        Point3d translated = DistanceFromEllipsoidSurfaceOp.ToEllipsoidCoordinates(point,ellipsoid);
+        Point3d translated = DistanceFromEllipsoidSurfaceOp.toEllipsoidCoordinates(point,ellipsoid);
         assertEquals(0.0,translated.x,1.0e-12);
         assertEquals(0.0,translated.y,1.0e-12);
         assertEquals(1.0,translated.z,1.0e-12);
@@ -126,20 +158,13 @@ public class DistanceFromEllipsoidSurfaceOpTest {
         ellipsoid.setOrientation(new Matrix3d(0,0,1,0,-1,0,1,0,0));
         Point3d point  = new Point3d(0,0,8);
 
-        Point3d rotated = DistanceFromEllipsoidSurfaceOp.ToEllipsoidCoordinates(point,ellipsoid);
+        Point3d rotated = DistanceFromEllipsoidSurfaceOp.toEllipsoidCoordinates(point,ellipsoid);
         assertEquals(8.0,rotated.x,1.0e-12);
         assertEquals(0.0,rotated.y,1.0e-12);
         assertEquals(0.0,rotated.z,1.0e-12);
 
     }
 
-    // main method for manual visual testing
-    public static void main(String[] args) {
-       // Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
-
-
-      //  vectors.stream().map(Vector3d::toString).forEach(System.out::println);
-    }
     @AfterClass
     public static void tearDownAfterClass() throws Exception {
         IMAGE_J.context().dispose();

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOpTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/DistanceFromEllipsoidSurfaceOpTest.java
@@ -1,0 +1,147 @@
+package org.bonej.ops.ellipsoid;
+
+import net.imagej.ImageJ;
+import net.imagej.ops.special.function.BinaryFunctionOp;
+import net.imagej.ops.special.function.Functions;
+import net.imglib2.type.numeric.real.DoubleType;
+import org.apache.commons.math3.random.UnitSphereRandomVectorGenerator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.scijava.vecmath.Matrix3d;
+import org.scijava.vecmath.Point3d;
+import org.scijava.vecmath.Vector3d;
+
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Tests for {@link DistanceFromEllipsoidSurfaceOp}.
+ *
+ * @author Alessandro Felder
+ */
+public class DistanceFromEllipsoidSurfaceOpTest {
+
+    private static final ImageJ IMAGE_J = new ImageJ();
+    private static BinaryFunctionOp<Ellipsoid, Point3d, DoubleType> distanceFromEllipsoidSurfaceOp;
+    private static UnitSphereRandomVectorGenerator sphereRng = new UnitSphereRandomVectorGenerator(3);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        distanceFromEllipsoidSurfaceOp = Functions.binary(IMAGE_J.op(), DistanceFromEllipsoidSurfaceOp.class, DoubleType.class, Ellipsoid.class, Point3d.class);
+    }
+
+    @Test
+    public void testDistanceOnAxesForAxisAlignedEllipsoid(){
+
+        Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+
+        Point3d outsidePoint  = new Point3d(2.0,0.0,0.0);
+        Point3d insidePoint  = new Point3d(0.0,1.0,0.0);
+        Point3d surfacePoint  = new Point3d(0.0,0.0,3.0);
+
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
+
+        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
+        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
+        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
+
+    }
+
+    //Ellipsoid and points from previous test translated by (1,1,1) and rotated 30 degrees around x-axis
+    @Test
+    public void testDistanceOnAxesForArbitraryEllipsoid(){
+
+        Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+        ellipsoid.setOrientation(new Matrix3d(1,0,0,0,Math.sqrt(3.0)/2.0,0.5,0,-0.5,Math.sqrt(3.0)/2.0));
+        ellipsoid.setCentroid(new Vector3d(1,1,1));
+
+        Point3d outsidePoint  = new Point3d(1.0+2.0,1.0,1.0);
+        Point3d insidePoint  = new Point3d(1.0,1.0+Math.sqrt(3.0)/2.0,1-0.5);
+        Point3d surfacePoint  = new Point3d(1.0,1.0+1.5,1.0+3.0*Math.sqrt(3.0)/2.0);
+
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
+
+        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
+        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
+        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
+
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void testDistanceOriginToUnitSphere() throws Exception
+    {
+        Ellipsoid ellipsoid = new Ellipsoid(2.0, 2.0, 2.0);
+        Point3d origin = new Point3d(0.0,0.0,0.0);
+        distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,origin).get();
+    }
+
+    @Test
+    public void testRandomPointsFromSphere()
+    {
+        final Supplier<Vector3d> spherePointSupplier = () -> new Vector3d(sphereRng.nextVector());
+        Vector3d sphereVector = new Vector3d(spherePointSupplier.get());
+        Ellipsoid ellipsoid = new Ellipsoid(2.0, 2.0, 2.0);
+
+        Point3d insidePoint  = new Point3d(sphereVector);
+        sphereVector.scale(2.0);
+        Point3d surfacePoint  = new Point3d(sphereVector);
+        sphereVector.scale(3.0/2.0);
+        Point3d outsidePoint  = new Point3d(sphereVector);
+
+        double distanceToOutsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,outsidePoint).get();
+        double distanceToInsidePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,insidePoint).get();
+        double distanceToSurfacePoint = distanceFromEllipsoidSurfaceOp.calculate(ellipsoid,surfacePoint).get();
+
+        assertEquals("Distance to outside point failed",1.0,distanceToOutsidePoint,1.0e-12);
+        assertEquals("Distance to inside point failed",1.0,distanceToInsidePoint,1.0e-12);
+        assertEquals("Distance to surface point failed",0.0,distanceToSurfacePoint,1.0e-12);
+    }
+
+    @Test
+    public void testTranslationTransformation()
+    {
+        Ellipsoid ellipsoid = new Ellipsoid(2.0, 2.0, 2.0);
+        ellipsoid.setCentroid(new Vector3d(5,7,8));
+        Point3d point  = new Point3d(5,7,9);
+
+        Point3d translated = DistanceFromEllipsoidSurfaceOp.ToEllipsoidCoordinates(point,ellipsoid);
+        assertEquals(0.0,translated.x,1.0e-12);
+        assertEquals(0.0,translated.y,1.0e-12);
+        assertEquals(1.0,translated.z,1.0e-12);
+
+    }
+
+    @Test
+    public void testRotationTransformation()
+    {
+        Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+        ellipsoid.setOrientation(new Matrix3d(0,0,1,0,-1,0,1,0,0));
+        Point3d point  = new Point3d(0,0,8);
+
+        Point3d rotated = DistanceFromEllipsoidSurfaceOp.ToEllipsoidCoordinates(point,ellipsoid);
+        assertEquals(8.0,rotated.x,1.0e-12);
+        assertEquals(0.0,rotated.y,1.0e-12);
+        assertEquals(0.0,rotated.z,1.0e-12);
+
+    }
+
+    // main method for manual visual testing
+    public static void main(String[] args) {
+       // Ellipsoid ellipsoid = new Ellipsoid(1.0, 2.0, 3.0);
+
+
+      //  vectors.stream().map(Vector3d::toString).forEach(System.out::println);
+    }
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        IMAGE_J.context().dispose();
+    }
+}


### PR DESCRIPTION
A simple op that numerically calculates the
shortest distance from a point to the ellipsoid
surface, provided there is a unique solution.
This may come in handy for quantifying the 
error of the ellipsoid fitting in the Anisotropy
wrapper as well as any ellipsoid-fitting at local
trabecular bone scales (EF, tensor scale,etc).