### PR TITLE
Refactor QuadricToEllipsoid op

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuadricToEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuadricToEllipsoid.java
@@ -80,7 +80,7 @@ public class QuadricToEllipsoid extends
 	 * @param quadric the general equation of a quadric in algebraic matrix form.
 	 * @return the 3D center point in a vector.
 	 */
-	private Vector3d findCenter(final Matrix4d quadric) {
+	private static Vector3d findCenter(final Matrix4d quadric) {
 		// @formatter:off
 		final GMatrix sub = new GMatrix(3, 3, new double[] {
 				quadric.m00, quadric.m01, quadric.m02,
@@ -112,7 +112,7 @@ public class QuadricToEllipsoid extends
 	 * @param eigenvalues eigenvalues of a quadric surface
 	 * @return true if the surface is an ellipsoid, false otherwise.
 	 */
-	private boolean isEllipsoid(final double[] eigenvalues) {
+	private static boolean isEllipsoid(final double[] eigenvalues) {
 		return Arrays.stream(eigenvalues).allMatch(x -> x > EIGENVALUE_TOLERANCE);
 	}
 
@@ -132,7 +132,9 @@ public class QuadricToEllipsoid extends
 		return new EigenDecomposition(input);
 	}
 
-	private Matrix3d toOrientationMatrix(final EigenDecomposition decomposition) {
+	private static Matrix3d toOrientationMatrix(
+		final EigenDecomposition decomposition)
+	{
 		final RealVector e1 = decomposition.getEigenvector(0);
 		final RealVector e2 = decomposition.getEigenvector(1);
 		final RealVector e3 = decomposition.getEigenvector(2);

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuadricToEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuadricToEllipsoid.java
@@ -4,6 +4,7 @@ package org.bonej.ops.ellipsoid;
 import java.util.Arrays;
 import java.util.Optional;
 
+import net.imagej.ops.Contingent;
 import net.imagej.ops.Op;
 import net.imagej.ops.special.function.AbstractUnaryFunctionOp;
 
@@ -40,7 +41,7 @@ import org.scijava.vecmath.Vector3d;
  */
 @Plugin(type = Op.class)
 public class QuadricToEllipsoid extends
-	AbstractUnaryFunctionOp<Matrix4d, Optional<Ellipsoid>>
+	AbstractUnaryFunctionOp<Matrix4d, Optional<Ellipsoid>> implements Contingent
 {
 
 	/**
@@ -72,6 +73,15 @@ public class QuadricToEllipsoid extends
 		final Matrix3d orientation = toOrientationMatrix(decomposition);
 		ellipsoid.setOrientation(orientation);
 		return Optional.of(ellipsoid);
+	}
+
+	@Override
+	public boolean conforms() {
+		final Matrix4d quadric = in();
+		final double a = quadric.m00;
+		final double b = quadric.m11;
+		final double c = quadric.m22;
+		return a > 0 && b > 0 && c > 0;
 	}
 
 	/**

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuadricToEllipsoidTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuadricToEllipsoidTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 
 import net.imagej.ImageJ;
@@ -50,9 +49,9 @@ public class QuadricToEllipsoidTest {
 	// Constant seed for random generators
 	private static final long SEED = 0xc0ffee;
 	@SuppressWarnings("unchecked")
-	private static UnaryFunctionOp<Matrix4d, Optional<Ellipsoid>> quadricToEllipsoid =
+	private static UnaryFunctionOp<Matrix4d, Ellipsoid> quadricToEllipsoid =
 		(UnaryFunctionOp) Functions.unary(IMAGE_J.op(), QuadricToEllipsoid.class,
-			Optional.class, UNIT_SPHERE);
+			Ellipsoid.class, UNIT_SPHERE);
 	@SuppressWarnings("unchecked")
 	private static BinaryFunctionOp<double[], Long, List<Vector3d>> ellipsoidPoints =
 		(BinaryFunctionOp) Functions.binary(IMAGE_J.op(), EllipsoidPoints.class,
@@ -104,13 +103,9 @@ public class QuadricToEllipsoidTest {
 		});
 		final Matrix4d quadric = (Matrix4d) IMAGE_J.op().run(SolveQuadricEq.class,
 			points);
-		final Optional<Ellipsoid> ellipsoidOptional = quadricToEllipsoid.calculate(
-			quadric);
+		final Ellipsoid ellipsoid = quadricToEllipsoid.calculate(quadric);
 
 		// VERIFY
-		assertTrue("Failed to fit transformed ellipsoid", ellipsoidOptional
-			.isPresent());
-		final Ellipsoid ellipsoid = ellipsoidOptional.get();
 		assertTrue("Ellipsoid centre point is not within tolerance", new Vector3d(0,
 			0, 0).epsilonEquals(ellipsoid.getCentroid(), 0.05));
 		assertEquals(radii[0], ellipsoid.getA(), 0.025);
@@ -147,13 +142,10 @@ public class QuadricToEllipsoidTest {
 		points.forEach(p -> p.add(centroid));
 		final Matrix4d quadric = (Matrix4d) IMAGE_J.op().run(SolveQuadricEq.class,
 			points);
-		final Optional<Ellipsoid> ellipsoidOptional = quadricToEllipsoid.calculate(
+		final Ellipsoid transformedEllipsoid = quadricToEllipsoid.calculate(
 			quadric);
 
 		// VERIFY
-		assertTrue("Failed to fit transformed ellipsoid", ellipsoidOptional
-			.isPresent());
-		final Ellipsoid transformedEllipsoid = ellipsoidOptional.get();
 		assertTrue(transformedEllipsoid.getCentroid().epsilonEquals(centroid,
 			1e-12));
 		assertEquals(radii[0], transformedEllipsoid.getA(), 1e-12);
@@ -165,14 +157,12 @@ public class QuadricToEllipsoidTest {
 
 	@Test
 	public void testUnitSphere() {
-		final Optional<Ellipsoid> sphereOptional = quadricToEllipsoid.calculate(
-			UNIT_SPHERE);
 		// A unit sphere has no orientation, so it's matrix will always be identity
 		final Matrix4d expectedOrientation = new Matrix4d();
 		expectedOrientation.setIdentity();
 
-		assertTrue("Failed to fit unit sphere", sphereOptional.isPresent());
-		final Ellipsoid unitSphere = sphereOptional.get();
+		final Ellipsoid unitSphere = quadricToEllipsoid.calculate(UNIT_SPHERE);
+
 		assertEquals(1.0, unitSphere.getA(), 1e-12);
 		assertEquals(1.0, unitSphere.getB(), 1e-12);
 		assertEquals(1.0, unitSphere.getC(), 1e-12);


### PR DESCRIPTION
- Op now implements `Contingent`, and `conforms()` fails if quadric doesn't have positive terms _a, b, c_
- Return type of op changed to `Ellipsoid` because it won't run if input cannot be converted to an ellipsoid.