### PR TITLE
Fix fit ellipsoid

### DIFF
--- a/IntegrationTestLogs/Anisotropy.txt
+++ b/IntegrationTestLogs/Anisotropy.txt
@@ -1,3 +1,5 @@
+// TODO Redo
+
 Manual integration tests for the Anisotropy command.
 They complement the automated wrapper tests in AnisotropyWrapperTest
 

--- a/IntegrationTestLogs/Anisotropy.txt
+++ b/IntegrationTestLogs/Anisotropy.txt
@@ -1,5 +1,3 @@
-// TODO Redo
-
 Manual integration tests for the Anisotropy command.
 They complement the automated wrapper tests in AnisotropyWrapperTest
 
@@ -53,7 +51,7 @@ Notes
 -----------------------------------------------------------------------
 If fitting fails, run again, or add directions.
 
-Completed March 12 2018 Richard Domander
+Completed July 6 2018 Richard Domander
 -----------------------------------------------------------------------
 
 

--- a/IntegrationTestLogs/FitEllipsoid.txt
+++ b/IntegrationTestLogs/FitEllipsoid.txt
@@ -1,3 +1,5 @@
+// TODO Redo
+
 Integration tests for the Fit Ellipsoid command.
 
 

--- a/IntegrationTestLogs/FitEllipsoid.txt
+++ b/IntegrationTestLogs/FitEllipsoid.txt
@@ -1,5 +1,3 @@
-// TODO Redo
-
 Integration tests for the Fit Ellipsoid command.
 
 
@@ -115,7 +113,7 @@ Expected result
 User sees the BoneJ results table with the radii and centroid 
 coordinates of an ellipsoid.
 
-Completed: November 12th 2017 Richard Domander
+Completed: July 6 2017 Richard Domander
 -----------------------------------------------------------------------
 
 

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuadricToEllipsoidTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuadricToEllipsoidTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 import net.imagej.ImageJ;
@@ -72,24 +73,27 @@ public class QuadricToEllipsoidTest {
 	// Constant seed for random generators
 	private static final long SEED = 0xc0ffee;
 	@SuppressWarnings("unchecked")
-	private static final UnaryFunctionOp<Matrix4d, Ellipsoid> quadricToEllipsoid =
+	private static final UnaryFunctionOp<Matrix4d, Optional<Ellipsoid>> quadricToEllipsoid =
 		(UnaryFunctionOp) Functions.unary(IMAGE_J.op(), QuadricToEllipsoid.class,
-			Ellipsoid.class, UNIT_SPHERE);
+			Optional.class, UNIT_SPHERE);
 	@SuppressWarnings("unchecked")
 	private static final BinaryFunctionOp<double[], Long, List<Vector3d>> ellipsoidPoints =
 		(BinaryFunctionOp) Functions.binary(IMAGE_J.op(), EllipsoidPoints.class,
 			List.class, new double[] { 1, 2, 3 }, 0);
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testConeFailsMatching() {
+	@Test
+	public void testCone() {
 		//@formatter:off
-        final Matrix4d cone = new Matrix4d(new double[]{
-                1, 0, 0, 0,
-                0, -1, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, -1});
-        //@formatter:on
-		IMAGE_J.op().run(QuadricToEllipsoid.class, cone);
+		final Matrix4d cone = new Matrix4d(new double[]{
+				1, 0, 0, 0,
+				0, -1, 0, 0,
+				0, 0, 1, 0,
+				0, 0, 0, -1});
+		//@formatter:on
+
+		final Optional<Ellipsoid> result = quadricToEllipsoid.calculate(cone);
+
+		assertFalse(result.isPresent());
 	}
 
 	/**
@@ -126,30 +130,17 @@ public class QuadricToEllipsoidTest {
 		});
 		final Matrix4d quadric = (Matrix4d) IMAGE_J.op().run(SolveQuadricEq.class,
 			points);
-		final Ellipsoid ellipsoid = quadricToEllipsoid.calculate(quadric);
+		final Optional<Ellipsoid> result = quadricToEllipsoid.calculate(quadric);
 
 		// VERIFY
+		assertTrue(result.isPresent());
+		final Ellipsoid ellipsoid = result.get();
 		assertTrue("Ellipsoid centre point is not within tolerance", new Vector3d(0,
 			0, 0).epsilonEquals(ellipsoid.getCentroid(), 0.05));
 		assertEquals(radii[0], ellipsoid.getA(), 0.025);
 		assertEquals(radii[1], ellipsoid.getB(), 0.025);
 		assertEquals(radii[2], ellipsoid.getC(), 0.025);
 		assertTrue(symmetry.epsilonEquals(ellipsoid.getOrientation(), 0.025));
-	}
-
-	@Test
-	public void testNanRadiusIsNotEllipsoid() {
-		// This quadric looks like an ellipsoid (3x3 diagonals positive), but it has
-		// a NaN radius (negative eigenvalue). These typically result from quadrics
-		// solved from sparse data.
-		final Matrix4d nanRadiusEllipsoid = new Matrix4d(new double[] {
-			0.01085019421630129, -0.026230819423660012, -0.0012390257941481408,
-			0.016336103119147793, -0.026230819423660012, 0.02043899336863353,
-			0.01731688607718951, 0.03182508790873584, -0.0012390257941481408,
-			0.01731688607718951, 0.2516413880666182, 0.0022183414533909485,
-			0.016336103119147793, 0.03182508790873584, 0.0022183414533909485, -1.0 });
-
-		assertFalse(QuadricToEllipsoid.isEllipsoid(nanRadiusEllipsoid));
 	}
 
 	/**
@@ -180,10 +171,11 @@ public class QuadricToEllipsoidTest {
 		points.forEach(p -> p.add(centroid));
 		final Matrix4d quadric = (Matrix4d) IMAGE_J.op().run(SolveQuadricEq.class,
 			points);
-		final Ellipsoid transformedEllipsoid = quadricToEllipsoid.calculate(
-			quadric);
+		final Optional<Ellipsoid> result = quadricToEllipsoid.calculate(quadric);
 
 		// VERIFY
+		assertTrue(result.isPresent());
+		final Ellipsoid transformedEllipsoid = result.get();
 		assertTrue(transformedEllipsoid.getCentroid().epsilonEquals(centroid,
 			1e-12));
 		assertEquals(radii[0], transformedEllipsoid.getA(), 1e-12);
@@ -199,8 +191,11 @@ public class QuadricToEllipsoidTest {
 		final Matrix4d expectedOrientation = new Matrix4d();
 		expectedOrientation.setIdentity();
 
-		final Ellipsoid unitSphere = quadricToEllipsoid.calculate(UNIT_SPHERE);
+		final Optional<Ellipsoid> result = quadricToEllipsoid.calculate(
+			UNIT_SPHERE);
 
+		assertTrue(result.isPresent());
+		final Ellipsoid unitSphere = result.get();
 		assertEquals(1.0, unitSphere.getA(), 1e-12);
 		assertEquals(1.0, unitSphere.getB(), 1e-12);
 		assertEquals(1.0, unitSphere.getC(), 1e-12);

--- a/Modern/utilities/src/main/java/org/bonej/utilities/RoiManagerUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/RoiManagerUtil.java
@@ -97,7 +97,6 @@ public final class RoiManagerUtil {
 			return Collections.emptyList();
 		}
 		final Roi[] rois = manager.getRoisAsArray();
-		// TODO Add unit test for multi-point ROIs
 		return Arrays.stream(rois).filter(roi -> roi.getType() == Roi.POINT).map(
 			roi -> {
 				final int z = roi.getZPosition();

--- a/Modern/utilities/src/main/java/org/bonej/utilities/RoiManagerUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/RoiManagerUtil.java
@@ -97,16 +97,13 @@ public final class RoiManagerUtil {
 			return Collections.emptyList();
 		}
 		final Roi[] rois = manager.getRoisAsArray();
-		// To be completely accurate, we'd have to calculate the centers of the ROIs
-		// bounding boxes, but since we're only interested in point ROIs that won't
-		// make a huge difference.
+		// TODO Add unit test for multi-point ROIs
 		return Arrays.stream(rois).filter(roi -> roi.getType() == Roi.POINT).map(
 			roi -> {
-				final double x = roi.getXBase();
-				final double y = roi.getYBase();
 				final int z = roi.getZPosition();
-				return new Vector3d(x, y, z);
-			}).collect(Collectors.toList());
+				return Arrays.stream(roi.getContainedPoints()).distinct().map(
+					p -> new Vector3d(p.x, p.y, z));
+			}).flatMap(s -> s).distinct().collect(Collectors.toList());
 	}
 
 	// endregion

--- a/Modern/utilities/src/test/java/org/bonej/utilities/RoiManagerUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/RoiManagerUtilTest.java
@@ -462,6 +462,27 @@ public class RoiManagerUtilTest {
 		assertEquals(pointRoi.getPosition(), point.z, 1e-12);
 	}
 
+	// Tests that the method filters out duplicate points within and between
+	// multi-point ROIs. Duplicate points have the same (x, y, z) coordinates.
+	@Test
+	public void testPointRoiCoordinatesMultiPointRois() {
+		final PointRoi roi = new PointRoi(new int[] { 1, 1, 2 }, new int[] { 0, 0,
+			0 }, 3);
+		roi.setPosition(1);
+		final PointRoi roi2 = new PointRoi(new int[] { 1, 1 }, new int[] { 0, 0 },
+			2);
+		roi2.setPosition(2);
+		when(MOCK_ROI_MANAGER.getRoisAsArray()).thenReturn(new Roi[] { roi, roi2 });
+
+		final List<Vector3d> result = RoiManagerUtil.pointROICoordinates(
+			MOCK_ROI_MANAGER);
+
+		assertEquals(3, result.size());
+		assertEquals(new Vector3d(1, 0, 1), result.get(0));
+		assertEquals(new Vector3d(2, 0, 1), result.get(1));
+		assertEquals(new Vector3d(1, 0, 2), result.get(2));
+	}
+
 	@Test
 	public void testPointRoiCoordinatesReturnsEmptyListIfManagerNull() {
 		final List<Vector3d> points = RoiManagerUtil.pointROICoordinates(null);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -28,7 +28,6 @@ import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -111,15 +110,15 @@ public class FitEllipsoidWrapper extends ContextCommand {
 		final Matrix4d quadric = (Matrix4d) opService.run(SolveQuadricEq.class,
 			points);
 		statusService.showStatus("Fit ellipsoid: determining ellipsoid parameters");
-		@SuppressWarnings("unchecked")
-		final Optional<Ellipsoid> result = (Optional<Ellipsoid>) opService.run(
-			QuadricToEllipsoid.class, quadric);
-		if (!result.isPresent()) {
+		if (!QuadricToEllipsoid.isEllipsoid(quadric)) {
 			cancel("Can't fit ellipsoid to points.\n" +
-				"Add more point ROI's to the ROI Manager and try again.");
+				"Try adding more point ROIs to the ROI Manager and try again.");
 			return;
 		}
-		addResults(result.get());
+		@SuppressWarnings("unchecked")
+		final Ellipsoid result = (Ellipsoid) opService.run(
+			QuadricToEllipsoid.class, quadric);
+		addResults(result);
 		if (SharedTable.hasData()) {
 			resultsTable = SharedTable.getTable();
 		}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -28,6 +28,7 @@ import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -110,15 +111,15 @@ public class FitEllipsoidWrapper extends ContextCommand {
 		final Matrix4d quadric = (Matrix4d) opService.run(SolveQuadricEq.class,
 			points);
 		statusService.showStatus("Fit ellipsoid: determining ellipsoid parameters");
-		if (!QuadricToEllipsoid.isEllipsoid(quadric)) {
+		@SuppressWarnings("unchecked")
+		final Optional<Ellipsoid> result = (Optional<Ellipsoid>) opService.run(
+			QuadricToEllipsoid.class, quadric);
+		if (!result.isPresent()) {
 			cancel("Can't fit ellipsoid to points.\n" +
 				"Try adding more point ROIs to the ROI Manager and try again.");
 			return;
 		}
-		@SuppressWarnings("unchecked")
-		final Ellipsoid result = (Ellipsoid) opService.run(
-			QuadricToEllipsoid.class, quadric);
-		addResults(result);
+		addResults(result.get());
 		if (SharedTable.hasData()) {
 			resultsTable = SharedTable.getTable();
 		}


### PR DESCRIPTION
* Fixes multi-point ROI handling in `RoiManagerUtil.pointROICoordinates`
* Fixes types in `FitEllipsoidWrapper` (wrong type caused op matching exception)
* Fixes `QuadricToEllipsoid`op. The check we had for input to see if it can result in an ellipsoid was incorrect, and it filtered out matrices that could have been constructed into ellipsoids. For some reason the Sylvester rule (positive determinants of submatrices) isn't enough in this case to check if eigenvalues of the solution will be positive.
* Updates tests