### PR TITLE
Fix #107

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/CommonMessages.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/CommonMessages.java
@@ -38,7 +38,6 @@ public final class CommonMessages {
 	static final String NOT_8_BIT_BINARY_IMAGE = "Need an 8-bit binary image";
 	static final String NO_IMAGE_OPEN = "No image open";
 	static final String NO_SKELETONS = "Image contained no skeletons";
-	static final String BAD_CALIBRATION = "Calibration cannot be determined";
 
 	private CommonMessages() {}
 }

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -23,12 +23,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.wrapperPlugins;
 
-import static org.bonej.wrapperPlugins.CommonMessages.BAD_CALIBRATION;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 import static org.scijava.ui.DialogPrompt.MessageType.INFORMATION_MESSAGE;
-import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -155,9 +153,6 @@ public class ConnectivityWrapper extends ContextCommand {
 
 	private void determineResultUnit() {
 		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, '³');
-		if (unitHeader.isEmpty()) {
-			uiService.showDialog(BAD_CALIBRATION, WARNING_MESSAGE);
-		}
 	}
 
 	// region -- Helper methods --

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -23,11 +23,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.wrapperPlugins;
 
-import static org.bonej.wrapperPlugins.CommonMessages.BAD_CALIBRATION;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 import static org.bonej.wrapperPlugins.CommonMessages.WEIRD_SPATIAL;
-import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 
 import net.imagej.ImgPlus;
 import net.imagej.ops.OpService;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -132,9 +132,6 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>>
 		final char exponent = ResultUtils.getExponent(inputImage);
 		final String unitHeader = ResultUtils.getUnitHeader(inputImage, unitService,
 			exponent);
-		if (unitHeader.isEmpty()) {
-			uiService.showDialog(BAD_CALIBRATION, WARNING_MESSAGE);
-		}
 		final String sizeDescription = ResultUtils.getSizeDescription(inputImage);
 
 		boneSizeHeader = "Bone " + sizeDescription.toLowerCase() + " " + unitHeader;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
@@ -24,7 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.bonej.wrapperPlugins;
 
 import static org.bonej.utilities.Streamers.spatialAxisStream;
-import static org.bonej.wrapperPlugins.CommonMessages.BAD_CALIBRATION;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
@@ -295,9 +295,6 @@ public class IsosurfaceWrapper<T extends RealType<T> & NativeType<T>> extends
 
 	private void prepareResults() {
 		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, '²');
-		if (unitHeader.isEmpty()) {
-			uiService.showDialog(BAD_CALIBRATION, WARNING_MESSAGE);
-		}
 
 		if (isAxesMatchingSpatialCalibration(inputImage)) {
 			final double scale = inputImage.axis(0).averageScale(0.0, 1.0);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -23,11 +23,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.wrapperPlugins;
 
-import static org.bonej.wrapperPlugins.CommonMessages.BAD_CALIBRATION;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
-import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -194,9 +194,6 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>>
 		final char exponent = ResultUtils.getExponent(inputImage);
 		final String unitHeader = ResultUtils.getUnitHeader(inputImage, unitService,
 			exponent);
-		if (unitHeader.isEmpty()) {
-			uiService.showDialog(BAD_CALIBRATION, WARNING_MESSAGE);
-		}
 		bVHeader = "Bone volume " + unitHeader;
 		tVHeader = "Total volume " + unitHeader;
 		elementSize = ElementUtil.calibratedSpatialElementSize(inputImage,

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtils.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtils.java
@@ -153,8 +153,7 @@ public final class ResultUtils {
 		}
 
 		final String unitHeader = unit.get();
-		if ("pixel".equalsIgnoreCase(unitHeader) || "unit".equalsIgnoreCase(
-			unitHeader) || unitHeader.isEmpty())
+		if (unitHeader.isEmpty())
 		{
 			// Don't show default units
 			return "";

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/CommonWrapperTests.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/CommonWrapperTests.java
@@ -23,7 +23,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.wrapperPlugins;
 
-import static org.bonej.wrapperPlugins.CommonMessages.BAD_CALIBRATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,9 +35,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.IntStream;
 
@@ -143,38 +139,6 @@ public final class CommonWrapperTests {
 			.getCancelReason());
 		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
-	}
-
-	static <C extends Command> void testNoCalibrationShowsWarning(
-		final Gateway imageJ, final Class<C> commandClass,
-		final Object... additionalInputs) throws Exception
-	{
-		// SETUP
-		// Mock UI
-		final UserInterface mockUI = mock(UserInterface.class);
-		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(mockUI.dialogPrompt(eq(BAD_CALIBRATION), anyString(), eq(
-			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
-		imageJ.ui().setDefaultUI(mockUI);
-		// Create an hyperstack with no calibration
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z);
-		final DefaultLinearAxis tAxis = new DefaultLinearAxis(Axes.TIME);
-		final Img<DoubleType> img = ArrayImgs.doubles(5, 5, 5, 2);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis, zAxis, tAxis);
-		final Collection<Object> inputs = new ArrayList<>();
-		inputs.add("inputImage");
-		inputs.add(imgPlus);
-		Collections.addAll(inputs, additionalInputs);
-
-		// EXECUTE
-		imageJ.command().run(commandClass, true, inputs.toArray()).get();
-
-		// VERIFY
-		verify(mockUI, timeout(1000).times(1)).dialogPrompt(eq(BAD_CALIBRATION),
-			anyString(), eq(WARNING_MESSAGE), any());
 	}
 
 	static <C extends Command> void testNonBinaryImagePlusCancelsPlugin(

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -118,12 +118,6 @@ public class ConnectivityWrapperTest {
 	}
 
 	@Test
-	public void testNoCalibrationShowsWarning() throws Exception {
-		CommonWrapperTests.testNoCalibrationShowsWarning(IMAGE_J,
-			ConnectivityWrapper.class);
-	}
-
-	@Test
 	public void testNonBinaryImageCancelsConnectivity() throws Exception {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			ConnectivityWrapper.class);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -72,12 +72,6 @@ public class ElementFractionWrapperTest {
 	}
 
 	@Test
-	public void testNoCalibrationShowsWarning() throws Exception {
-		CommonWrapperTests.testNoCalibrationShowsWarning(IMAGE_J,
-			ElementFractionWrapper.class);
-	}
-
-	@Test
 	public void testNonBinaryImageCancelsElementFraction() throws Exception {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			ElementFractionWrapper.class);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IsosurfaceWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IsosurfaceWrapperTest.java
@@ -225,12 +225,6 @@ public class IsosurfaceWrapperTest {
 	}
 
 	@Test
-	public void testNoCalibrationShowsWarning() throws Exception {
-		CommonWrapperTests.testNoCalibrationShowsWarning(IMAGE_J,
-			IsosurfaceWrapper.class, "exportSTL", false);
-	}
-
-	@Test
 	public void testNonBinaryImageCancelsIsosurface() throws Exception {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			IsosurfaceWrapper.class);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -68,12 +68,6 @@ public class SurfaceFractionWrapperTest {
 	}
 
 	@Test
-	public void testNoCalibrationShowsWarning() throws Exception {
-		CommonWrapperTests.testNoCalibrationShowsWarning(IMAGE_J,
-			SurfaceFractionWrapper.class);
-	}
-
-	@Test
 	public void testNonBinaryImageCancelsSurfaceFraction() throws Exception {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			SurfaceFractionWrapper.class);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
@@ -212,32 +212,36 @@ public class ResultUtilsTest {
 	}
 
 	@Test
-	public void testGetUnitHeaderReturnEmptyIfDefaultUnitPixel() {
-		final DefaultLinearAxis axis = new DefaultLinearAxis(Axes.X, "pixel");
-		final Img<DoubleType> img = ArrayImgs.doubles(10);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
-
-		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
-
-		assertTrue("Unit header should be empty", result.isEmpty());
-	}
-
-	@Test
-	public void testGetUnitHeaderReturnEmptyIfDefaultUnitUnit() {
-		final DefaultLinearAxis axis = new DefaultLinearAxis(Axes.X, "unit");
-		final Img<DoubleType> img = ArrayImgs.doubles(10);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
-
-		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
-
-		assertTrue("Unit header should be empty", result.isEmpty());
-	}
-
-	@Test
 	public void testGetUnitHeaderReturnEmptyIfImageNull() {
 		final String result = ResultUtils.getUnitHeader(null, unitService, '³');
 
 		assertTrue("Unit header should be empty", result.isEmpty());
+	}
+
+	@Test
+	public void testGetUnitHeaderReturnPixelIfDefaultUnitPixel() {
+		final String unit = "pixel";
+		final String expected = "(" + unit + "³)";
+		final DefaultLinearAxis axis = new DefaultLinearAxis(Axes.X, unit);
+		final Img<DoubleType> img = ArrayImgs.doubles(10);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
+
+		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
+
+		assertEquals(expected, result);
+	}
+
+	@Test
+	public void testGetUnitHeaderReturnUnitIfDefaultUnitUnit() {
+		final String unit = "unit";
+		final String expected = "(" + unit + "³)";
+		final DefaultLinearAxis axis = new DefaultLinearAxis(Axes.X, unit);
+		final Img<DoubleType> img = ArrayImgs.doubles(10);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
+
+		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
+
+		assertEquals(expected, result);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes issue #107 in ConnectivityWrapper, and makes behaviour consistent in other similar cases. That is, plug-ins don't warn user about calibration any more if they can't find the unit of measurement. They simply show the measurement in "pixel" units.