### PR TITLE
Put all the BoneJ plugins in the same menu

### DIFF
--- a/Legacy/bonej/src/main/resources/plugins.config
+++ b/Legacy/bonej/src/main/resources/plugins.config
@@ -21,19 +21,19 @@
 ###
 # Author: Michael Doube
 
-Plugins>BoneJ Legacy>Analyze, "Orientation", org.bonej.plugins.Orienteer
-Plugins>BoneJ Legacy>Analyze, "Particle Analyser", org.bonej.plugins.ParticleCounter
-Plugins>BoneJ Legacy>Analyze, "Calibrate SCANCO", org.bonej.plugins.DensityCalibrator("scanco")
+Plugins>BoneJ>Analyze, "Orientation", org.bonej.plugins.Orienteer
+Plugins>BoneJ>Analyze, "Particle Analyser", org.bonej.plugins.ParticleCounter
+Plugins>BoneJ>Analyze, "Calibrate SCANCO", org.bonej.plugins.DensityCalibrator("scanco")
 
-Plugins>BoneJ Legacy>, "Ellipsoid Factor", org.bonej.plugins.EllipsoidFactor
-Plugins>BoneJ Legacy>, "Optimise Threshold",org.bonej.plugins.ThresholdMinConn
-Plugins>BoneJ Legacy>, "Purify", org.bonej.plugins.Purify
+Plugins>BoneJ>, "Ellipsoid Factor", org.bonej.plugins.EllipsoidFactor
+Plugins>BoneJ>, "Optimise Threshold",org.bonej.plugins.ThresholdMinConn
+Plugins>BoneJ>, "Purify", org.bonej.plugins.Purify
 
-Plugins>BoneJ Legacy>, "Fit Sphere", org.bonej.plugins.SphereFitter
-Plugins>BoneJ Legacy>, "Moments of Inertia", org.bonej.plugins.Moments
-Plugins>BoneJ Legacy>, "Slice Geometry", org.bonej.plugins.SliceGeometry
+Plugins>BoneJ>, "Fit Sphere", org.bonej.plugins.SphereFitter
+Plugins>BoneJ>, "Moments of Inertia", org.bonej.plugins.Moments
+Plugins>BoneJ>, "Slice Geometry", org.bonej.plugins.SliceGeometry
 
-Plugins>BoneJ Legacy>Stacks, "Delete Slice Range", org.bonej.plugins.DeleteSliceRange
-Plugins>BoneJ Legacy>Stacks, "Check Voxel Depth", org.bonej.plugins.VoxelDepthChecker
+Plugins>BoneJ>Stacks, "Delete Slice Range", org.bonej.plugins.DeleteSliceRange
+Plugins>BoneJ>Stacks, "Check Voxel Depth", org.bonej.plugins.VoxelDepthChecker
 
 Edit>Options, "BoneJ Usage",  org.bonej.plugins.ReporterOptions


### PR DESCRIPTION
Legacy and IJ2 plugins are separated by a line. Whether a plugin is
legacy or not should be relatively invisible to end users.