### PR TITLE
Fix result inserter logic (Legacy)

### DIFF
--- a/Legacy/util/src/main/java/org/bonej/util/ResultInserter.java
+++ b/Legacy/util/src/main/java/org/bonej/util/ResultInserter.java
@@ -57,9 +57,9 @@ public final class ResultInserter {
 	{
 		final String title = imp.getTitle();
 
-		// search for the first row that contains the image title
+		// search for the last value that contains the image title
 		// and contains no value for the heading
-		for (int row = 0; row < rt.getCounter(); row++) {
+		for (int row = rt.getCounter()-1; row >= 0; row--) {
 			if (rt.getLabel(row) == null) {
 				rt.setLabel(title, row);
 			}


### PR DESCRIPTION
Result inserter works more intuitively if a bunch of new results are added to the last line rather than the first line a duplicate entry is found.