### PR TITLE
Updates to SharedTable

### DIFF
--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -193,21 +193,22 @@ public final class SharedTable {
 		final int columnIndex, final String value)
 	{
 		final int rows = table.getRowCount();
-		final DefaultColumn<String> labelColumn = table.get(LABEL_HEADER);
-		int alphabeticalIndex = IntStream.range(0, rows).filter(i -> labelColumn
-			.get(i).compareTo(label) >= 0).findFirst().orElse(rows);
-		while (alphabeticalIndex < rows && labelColumn.get(alphabeticalIndex)
-			.equals(label))
-		{
-			final String cell = table.get(columnIndex).get(alphabeticalIndex);
-			if (cell == null || EMPTY_CELL.equals(cell)) {
-				table.set(columnIndex, alphabeticalIndex, value);
-				return;
+		//iterate up the table from the bottom
+		for (int i = rows-1; i >=0; i--) {
+			//if we find a row with the same label
+			if (table.get(LABEL_HEADER, i).equals(label)) {
+				//check whether there is not already a value in columnIndex
+				final String cell = table.get(columnIndex, i); 
+				if (cell.isEmpty() || cell == null) {
+					//add the value to the row and column
+					table.set(columnIndex, i, value);
+					return;
+				}
 			}
-			alphabeticalIndex++;
 		}
-		insertEmptyRow(label, alphabeticalIndex);
-		table.set(columnIndex, alphabeticalIndex, value);
+		//we didn't find the label in the table so make a new row
+		insertEmptyRow(label, rows);
+		table.set(columnIndex, rows, value);
 	}
 	// endregion
 }

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -58,8 +58,7 @@ public final class SharedTable {
 	public static final Double EMPTY_CELL = null;
 
 	/**
-	 * The table uses Double values. Numerical columns cannot have empty cells.
-	 * Empty cells are indicated by Double.NaN
+	 * The table uses Double values. Empty cells are indicated by null
 	 */
 	private static Table<DefaultColumn<Double>, Double> table = createTable();
 

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -67,7 +67,7 @@ public final class SharedTable {
 	/**
 	 * Adds new value as a {@link Double} to the shared table.
 	 *
-	 * @see #add(String, String, String)
+	 * @see #add(String, String, Double)
 	 * @param label the row label of the new data.
 	 * @param header the column heading of the new data.
 	 * @param value the value of the new data.

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -55,19 +55,18 @@ import org.scijava.util.StringUtils;
  */
 public final class SharedTable {
 
-	public static final String EMPTY_CELL = "";
+	public static final Double EMPTY_CELL = null;
 
 	/**
-	 * The table uses String values, so that we can mark empty cells with empty
-	 * Strings. Numerical columns cannot have empty cells. Unfortunately this
-	 * causes sorting in UI to work alphabetically, i.e. "1", "11", "2".
+	 * The table uses Double values. Numerical columns cannot have empty cells.
+	 * Empty cells are indicated by Double.NaN
 	 */
-	private static Table<DefaultColumn<String>, String> table = createTable();
+	private static Table<DefaultColumn<Double>, Double> table = createTable();
 
 	private SharedTable() {}
 
 	/**
-	 * Adds new value as a {@link String} to the shared table.
+	 * Adds new value as a {@link Double} to the shared table.
 	 *
 	 * @see #add(String, String, String)
 	 * @param label the row label of the new data.
@@ -77,13 +76,13 @@ public final class SharedTable {
 	public static void add(final String label, final String header,
 		final long value)
 	{
-		add(label, header, String.valueOf(value));
+		add(label, header, new Double(value));
 	}
 
 	/**
-	 * Adds new value as a {@link String} to the shared table
+	 * Adds new value as a {@link Double} to the shared table
 	 *
-	 * @see #add(String, String, String)
+	 * @see #add(String, String, Double)
 	 * @param label the row label of the new data.
 	 * @param header the column heading of the new data.
 	 * @param value the value of the new data.
@@ -91,7 +90,7 @@ public final class SharedTable {
 	public static void add(final String label, final String header,
 		final double value)
 	{
-		add(label, header, String.valueOf(value));
+		add(label, header, new Double(value));
 	}
 
 	/**
@@ -106,7 +105,7 @@ public final class SharedTable {
 	 * @param value the value of the new data.
 	 */
 	public static void add(final String label, final String header,
-		final String value)
+		final Double value)
 	{
 		if (StringUtils.isNullOrEmpty(label) || StringUtils.isNullOrEmpty(header)) {
 			return;
@@ -126,13 +125,12 @@ public final class SharedTable {
 	 *
 	 * @return the singleton table.
 	 */
-	public static Table<DefaultColumn<String>, String> getTable() {
+	public static Table<DefaultColumn<Double>, Double> getTable() {
 		return table;
 	}
 
 	public static boolean hasData() {
-		return table.stream().flatMap(Collection::stream).anyMatch(s -> s != null &&
-			!EMPTY_CELL.equals(s));
+		return table.stream().flatMap(Collection::stream).anyMatch(s -> s != null );
 	}
 
 	/** Initializes the table into a new empty table */
@@ -155,13 +153,13 @@ public final class SharedTable {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static Table<DefaultColumn<String>, String> createTable() {
+	private static Table<DefaultColumn<Double>, Double> createTable() {
 		final Table newTable = new DefaultGenericTable();
 		return newTable;
 	}
 
 	private static void fillEmptyColumn(final int columnIndex) {
-		final DefaultColumn<String> column = table.get(columnIndex);
+		final DefaultColumn<Double> column = table.get(columnIndex);
 		IntStream.range(0, column.size()).forEach(i -> column.set(i, EMPTY_CELL));
 	}
 
@@ -179,7 +177,7 @@ public final class SharedTable {
 	}
 	
 	private static void insertIntoNextFreeRow(final String label,
-		final int columnIndex, final String value)
+		final int columnIndex, final Double value)
 	{
 		final int rows = table.getRowCount();
 		//iterate up the table from the bottom
@@ -187,8 +185,8 @@ public final class SharedTable {
 			//if we find a row with the same label
 			if (table.getRowHeader(i).equals(label)) {
 				//check whether there is not already a value in columnIndex
-				final String cell = table.get(columnIndex, i); 
-				if (cell.isEmpty() || cell == null) {
+				final Double cell = table.get(columnIndex, i); 
+				if (cell == EMPTY_CELL) {
 					//add the value to the row and column
 					table.set(columnIndex, i, value);
 					return;

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -41,7 +41,7 @@ import org.scijava.util.StringUtils;
  * e.g. "Volume"</li>
  * <li>If there are no rows with the given label, then add a new row</li>
  * <li>If there are rows with the given label, but there is not a column with
- * the given heading, then add a column, and set its value on the first row with
+ * the given heading, then add a column, and set its value on the last row with
  * the label.</li>
  * <li>If there are rows with the given label, and there's a column with the
  * given heading, then find the first empty cell (equals {@link #EMPTY_CELL}),

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -24,6 +24,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.bonej.utilities;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 import net.imagej.table.DefaultColumn;
@@ -129,7 +130,7 @@ public final class SharedTable {
 	}
 
 	public static boolean hasData() {
-		return table.stream().flatMap(Collection::stream).anyMatch(s -> s != null );
+		return table.stream().flatMap(Collection::stream).anyMatch(Objects::nonNull);
 	}
 
 	/** Initializes the table into a new empty table */

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -78,7 +78,7 @@ public class SharedTableTest {
 		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(
 			s -> s == null).count());
 		final DefaultColumn<Double> column2 = table.get(header2);
-		assertEquals("Cell contains wrong value", new Double(3.0), column2.get(1));
+		assertEquals("Cell contains wrong value", 3.0, column2.get(1).doubleValue(), 1e-12);
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
 			s -> s == null).count());
 		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
@@ -134,7 +134,7 @@ public class SharedTableTest {
 		assertEquals(1, table.getColumnCount());
 		assertEquals(header, table.get(0).getHeader());
 		assertEquals(label, table.getRowHeader(0));
-		assertEquals(new Double(1.0), table.get(header).get(0));
+		assertEquals(1.0, table.get(header).get(0).doubleValue(), 1e-12);
 	}
 
 	@Test
@@ -148,10 +148,10 @@ public class SharedTableTest {
 		assertEquals(
 			"Adding data to the same column, to the row with the same label, should create a new row",
 			2, table.getRowCount());
-		assertEquals("Values in wrong order, older should be first", new Double(1), table.get(
-			"Run").get(0));
-		assertEquals("Values in wrong order, older should be first", new Double(2), table.get(
-			"Run").get(1));
+		assertEquals("Values in wrong order, older should be first", 1, table.get(
+			"Run").get(0).doubleValue(), 1e-12);
+		assertEquals("Values in wrong order, older should be first", 2, table.get(
+			"Run").get(1).doubleValue(), 1e-12);
 	}
 
 	@Test

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -24,7 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.bonej.utilities;
 
 import static org.bonej.utilities.SharedTable.EMPTY_CELL;
-import static org.bonej.utilities.SharedTable.LABEL_HEADER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +38,7 @@ import org.junit.Test;
  * Tests for {@link SharedTable}
  *
  * @author Richard Domander
+ * @author Michael Doube
  */
 public class SharedTableTest {
 
@@ -49,38 +49,39 @@ public class SharedTableTest {
 
 	/*
 	 * Test that the table is filled in the expected order:
-	 * Label    Measurement A   Measurement B
+	 *          Measurement 1   Measurement 2
+	 * Image B            -               2.0
+	 * Image A            1.0             3.0
 	 * Image A            1.0             2.0
-	 * Image A            1.0               -
-	 * Image B              -             2.0
 	 */
 	@Test
 	public void testAdd() {
 		// SETUP
-		final String label = "Image A";
-		final String label2 = "Image B";
-		final String header = "Measurement A";
-		final String header2 = "Measurement B";
+		final String labelA = "Image A";
+		final String labelB = "Image B";
+		final String header1 = "Measurement 1";
+		final String header2 = "Measurement 2";
 
 		// EXECUTE
-		SharedTable.add(label2, header2, 2.0);
-		SharedTable.add(label, header, 1.0);
-		SharedTable.add(label, header, 1.0);
-		SharedTable.add(label, header2, 2.0);
+		SharedTable.add(labelB, header2, 2.0);
+		SharedTable.add(labelA, header1, 1.0);
+		SharedTable.add(labelA, header1, 1.0);
+		SharedTable.add(labelA, header2, 2.0);
+		SharedTable.add(labelA, header2, 3.0);
 
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals("Wrong number of rows", 3, table.size());
-		final DefaultColumn<String> columnA = table.get(header);
-		assertEquals("Cell should be empty", EMPTY_CELL, columnA.get(2));
-		assertEquals("Wrong number of empty cells", 1, columnA.stream().filter(
+		assertEquals("Wrong number of columns", 2, table.getColumnCount());
+		assertEquals("Wrong number of rows", 3, table.getRowCount());
+		final DefaultColumn<String> column1 = table.get(header1);
+		assertEquals("Cell should be empty", EMPTY_CELL, column1.get(0));
+		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(
 			s -> s.equals(EMPTY_CELL)).count());
-		final DefaultColumn<String> columnB = table.get(header2);
-		assertEquals("Cell should be empty", EMPTY_CELL, columnB.get(1));
-		assertEquals("Wrong number of empty cells", 1, columnB.stream().filter(
+		final DefaultColumn<String> column2 = table.get(header2);
+		assertEquals("Cell contains wrong value", "3.0", column2.get(1));
+		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
 			s -> s.equals(EMPTY_CELL)).count());
-		assertEquals("Label on the wrong row", label2, table.get(LABEL_HEADER).get(
-			2));
+		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
 	}
 
 	@Test
@@ -113,7 +114,7 @@ public class SharedTableTest {
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
 		assertEquals(1, table.getRowCount());
-		assertEquals(3, table.getColumnCount());
+		assertEquals(2, table.getColumnCount());
 
 	}
 
@@ -130,39 +131,10 @@ public class SharedTableTest {
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
 		assertEquals(1, table.getRowCount());
-		assertEquals(2, table.getColumnCount());
-		assertEquals(LABEL_HEADER, table.get(0).getHeader());
-		assertEquals(label, table.get(LABEL_HEADER).get(0));
-		assertEquals(header, table.get(1).getHeader());
+		assertEquals(1, table.getColumnCount());
+		assertEquals(header, table.get(0).getHeader());
+		assertEquals(label, table.getRowHeader(0));
 		assertEquals(String.valueOf(value), table.get(header).get(0));
-	}
-
-	@Test
-	public void testAddRowsInsertedAlphabetically() {
-		// SETUP
-		final String label = "ZZZ";
-		final String label2 = "AAA";
-		final String label3 = "BBB";
-
-		// EXECUTE
-		SharedTable.add(label, "Header", 3.0);
-		SharedTable.add(label2, "Header", 1.0);
-		SharedTable.add(label3, "Header", 2.0);
-		SharedTable.add(label, "Header", 4.0);
-		SharedTable.add(label, "Header 2", 4.0);
-
-		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals(4, table.getRowCount());
-		assertEquals(label2, table.get(0, 0));
-		assertEquals(String.valueOf(1.0), table.get(1, 0));
-		assertEquals(label3, table.get(0, 1));
-		assertEquals(String.valueOf(2.0), table.get(1, 1));
-		assertEquals(label, table.get(0, 2));
-		assertEquals(String.valueOf(3.0), table.get(1, 2));
-		assertEquals(String.valueOf(4.0), table.get(2, 2));
-		assertEquals(label, table.get(0, 3));
-		assertEquals(String.valueOf(4.0), table.get(1, 3));
 	}
 
 	@Test
@@ -201,7 +173,7 @@ public class SharedTableTest {
 
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals(1, table.getColumnCount());
+		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
 
@@ -212,7 +184,7 @@ public class SharedTableTest {
 
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals(1, table.getColumnCount());
+		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
 
@@ -223,7 +195,7 @@ public class SharedTableTest {
 
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals(1, table.getColumnCount());
+		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
 
@@ -234,7 +206,7 @@ public class SharedTableTest {
 
 		// VERIFY
 		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
-		assertEquals(1, table.getColumnCount());
+		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
 }

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Objects;
+
 import net.imagej.table.DefaultColumn;
 import net.imagej.table.Table;
 
@@ -75,8 +77,7 @@ public class SharedTableTest {
 		assertEquals("Wrong number of rows", 3, table.getRowCount());
 		final DefaultColumn<Double> column1 = table.get(header1);
 		assertEquals("Cell should be empty", EMPTY_CELL, column1.get(0));
-		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(
-			s -> s == null).count());
+		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(Objects::isNull).count());
 		final DefaultColumn<Double> column2 = table.get(header2);
 		assertEquals("Cell contains wrong value", 3.0, column2.get(1).doubleValue(), 1e-12);
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -70,17 +70,17 @@ public class SharedTableTest {
 		SharedTable.add(labelA, header2, 3.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals("Wrong number of columns", 2, table.getColumnCount());
 		assertEquals("Wrong number of rows", 3, table.getRowCount());
-		final DefaultColumn<String> column1 = table.get(header1);
+		final DefaultColumn<Double> column1 = table.get(header1);
 		assertEquals("Cell should be empty", EMPTY_CELL, column1.get(0));
 		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(
-			s -> s.equals(EMPTY_CELL)).count());
-		final DefaultColumn<String> column2 = table.get(header2);
-		assertEquals("Cell contains wrong value", "3.0", column2.get(1));
+			s -> s == null).count());
+		final DefaultColumn<Double> column2 = table.get(header2);
+		assertEquals("Cell contains wrong value", new Double(3.0), column2.get(1));
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
-			s -> s.equals(EMPTY_CELL)).count());
+			s -> s == null).count());
 		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
 	}
 
@@ -96,7 +96,7 @@ public class SharedTableTest {
 		SharedTable.add(label, header, 1.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(3, table.getRowCount());
 	}
 
@@ -112,7 +112,7 @@ public class SharedTableTest {
 		SharedTable.add(label, header2, 3.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(1, table.getRowCount());
 		assertEquals(2, table.getColumnCount());
 
@@ -129,12 +129,12 @@ public class SharedTableTest {
 		SharedTable.add(label, header, value);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(1, table.getRowCount());
 		assertEquals(1, table.getColumnCount());
 		assertEquals(header, table.get(0).getHeader());
 		assertEquals(label, table.getRowHeader(0));
-		assertEquals(String.valueOf(value), table.get(header).get(0));
+		assertEquals(new Double(1.0), table.get(header).get(0));
 	}
 
 	@Test
@@ -144,13 +144,13 @@ public class SharedTableTest {
 		SharedTable.add("Image", "Value", 1.0);
 		SharedTable.add("Image", "Run", 2);
 
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(
 			"Adding data to the same column, to the row with the same label, should create a new row",
 			2, table.getRowCount());
-		assertEquals("Values in wrong order, older should be first", "1", table.get(
+		assertEquals("Values in wrong order, older should be first", new Double(1), table.get(
 			"Run").get(0));
-		assertEquals("Values in wrong order, older should be first", "2", table.get(
+		assertEquals("Values in wrong order, older should be first", new Double(2), table.get(
 			"Run").get(1));
 	}
 
@@ -172,7 +172,7 @@ public class SharedTableTest {
 		SharedTable.add("Label", "", 1.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
@@ -183,7 +183,7 @@ public class SharedTableTest {
 		SharedTable.add("", "Header", 1.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
@@ -194,7 +194,7 @@ public class SharedTableTest {
 		SharedTable.add("Label", null, 1.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}
@@ -205,7 +205,7 @@ public class SharedTableTest {
 		SharedTable.add(null, "Header", 1.0);
 
 		// VERIFY
-		final Table<DefaultColumn<String>, String> table = SharedTable.getTable();
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -127,7 +127,7 @@ public class AnalyseSkeletonWrapper extends ContextCommand {
 	 * results.
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>,Double> resultsTable;
 
 	/**
 	 * Additional analysis details in a {@link DefaultGenericTable}, null if

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -148,7 +148,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 	@Parameter
 	private LogService logService;
 	@Parameter
@@ -195,12 +195,9 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			suffix;
 		SharedTable.add(label, "Degree of anisotropy", anisotropy);
 		if (printRadii) {
-			SharedTable.add(label, "Radius a", String.format("%.2f", ellipsoid
-				.getA()));
-			SharedTable.add(label, "Radius b", String.format("%.2f", ellipsoid
-				.getB()));
-			SharedTable.add(label, "Radius c", String.format("%.2f", ellipsoid
-				.getC()));
+			SharedTable.add(label, "Radius a", ellipsoid.getA());
+			SharedTable.add(label, "Radius b", ellipsoid.getB());
+			SharedTable.add(label, "Radius c", ellipsoid.getC());
 		}
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -84,7 +84,7 @@ public class ConnectivityWrapper extends ContextCommand {
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private OpService opService;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -74,7 +74,7 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>>
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private OpService opService;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -87,7 +87,7 @@ public class FitEllipsoidWrapper extends ContextCommand {
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private OpService opService;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -141,7 +141,7 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>>
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	/**
 	 * Tables containing the (-log(size), log(count)) points for each 3D subspace

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -153,7 +153,7 @@ public class IntertrabecularAngleWrapper extends ContextCommand {
 
 	/** The ITA angles in a {@link Table}, null if there are no results */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> anglesTable;
+	private Table<DefaultColumn<Double>, Double> anglesTable;
 
 	/**
 	 * The ITA edge-end coordinates in a {@link Table}, null if there are no

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IsosurfaceWrapper.java
@@ -105,7 +105,7 @@ public class IsosurfaceWrapper<T extends RealType<T> & NativeType<T>> extends
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter(label = "Export STL file(s)",
 		description = "Create a binary STL file from the surface mesh",

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -95,7 +95,7 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>>
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private OpService opService;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -109,7 +109,7 @@ public class ThicknessWrapper extends ContextCommand {
 	 * </p>
 	 */
 	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<String>, String> resultsTable;
+	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private UIService uiService;

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -360,10 +360,10 @@ public class AnalyseSkeletonWrapperTest {
 			"# Junctions", "# End-point voxels", "# Junction voxels", "# Slab voxels",
 			"Average Branch Length", "# Triple points", "# Quadruple points",
 			"Maximum Branch Length", "Longest Shortest Path", "spx", "spy", "spz" };
-		final String[][] expectedValues = { { "1", "2" }, { "0", "0" }, { "0",
-			"0" }, { "1", "1" }, { "0", "0" }, { "0", "0" }, { "0.0", "0.0" }, { "0",
-				"0" }, { "0", "0" }, { "0.0", "0.0" }, { "0.0", "0.0" }, { "1.0",
-					"3.0" }, { "1.0", "3.0" }, { "0.0", "0.0" } };
+		final double[][] expectedValues = { { 1, 2 }, { 0, 0 }, { 0,
+			0 }, { 1, 1 }, { 0, 0 }, { 0, 0 }, { 0.0, 0.0 }, { 0,
+				0 }, { 0, 0 }, { 0.0, 0.0 }, { 0.0, 0.0 }, { 1.0,
+					3.0 }, { 1.0, 3.0 }, { 0.0, 0.0 } };
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(
@@ -372,19 +372,19 @@ public class AnalyseSkeletonWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
 		assertEquals("Results table has wrong number of columns",
-			expectedHeaders.length + 1, table.size());
-		for (int i = 0; i < table.size() - 1; i++) {
-			final DefaultColumn<String> column = table.get(i + 1);
+			expectedHeaders.length, table.size());
+		for (int i = 0; i < table.size(); i++) {
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals("Column has incorrect header", expectedHeaders[i], column
 				.getHeader());
 			assertEquals("Column has wrong number of rows", 2, column.size());
 			for (int j = 0; j < 2; j++) {
 				assertEquals("Column has an incorrect value", expectedValues[i][j],
-					column.get(j));
+					column.get(j).doubleValue(), 1e-12);
 			}
 		}
 	}
@@ -407,10 +407,10 @@ public class AnalyseSkeletonWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final Collection<DefaultColumn<String>> table =
-			(Collection<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final Collection<DefaultColumn<Double>> table =
+			(Collection<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Results table has wrong number of columns", 11, table.size());
+		assertEquals("Results table has wrong number of columns", 10, table.size());
 	}
 
 	/**

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -174,20 +174,19 @@ public class ConnectivityWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Results table has wrong number of columns", 5, table.size());
+		assertEquals("Results table has wrong number of columns", 4, table.size());
 		for (int i = 0; i < 4; i++) {
 			// Ignore column 0, the label column
-			final DefaultColumn<String> column = table.get(i + 1);
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals("A column has wrong number of rows", 4, column.size());
 			final String header = column.getHeader();
 			assertEquals("A column has an incorrect header", expectedHeaders.get(i),
 				header);
 			for (int j = 0; j < column.size(); j++) {
-				assertEquals(expectedValues[i][j], Double.parseDouble(column.get(j)),
-					1e-12);
+				assertEquals(expectedValues[i][j], column.get(j).doubleValue(),	1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -118,18 +118,18 @@ public class ElementFractionWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Wrong number of columns", 4, table.size());
+		assertEquals("Wrong number of columns", 3, table.size());
 		for (int i = 0; i < 3; i++) {
-			final DefaultColumn<String> column = table.get(i + 1);
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals("Column has wrong number of rows", 1, column.size());
 			assertEquals("Column has incorrect header", expectedHeaders[i], column
 				.getHeader());
 			for (int j = 0; j < 1; j++) {
 				assertEquals("Column has an incorrect value", expectedValues[i][j],
-					Double.parseDouble(column.get(j)), 1e-12);
+					column.get(j).doubleValue(), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -94,9 +94,6 @@ public class FractalDimensionWrapperTest {
 			.toArray();
 		final double[][] expectedCounts = { emptyCounts, cubeCounts, cubeCounts,
 			emptyCounts };
-//		final String[] expectedLabels = { "Test Channel: 1, Time: 1",
-//			"Test Channel: 2, Time: 1", "Test Channel: 1, Time: 2",
-//			"Test Channel: 2, Time: 2" };
 		final ImgPlus<BitType> imgPlus = createTestHyperStack("Test");
 
 		// EXECUTE
@@ -115,9 +112,6 @@ public class FractalDimensionWrapperTest {
 		for (int i = 0; i < pointTables.size(); i++) {
 			final GenericTable table = pointTables.get(i);
 			assertEquals("Table has wrong number of columns", 3, table.size());
-//			final Column<String> label = (Column<String>) table.get("Label");
-//			assertEquals("Label column has wrong number of rows", expectedRows, label
-//				.size());
 			final DoubleColumn sizes = (DoubleColumn) table.get("-log(size)");
 			assertEquals("Size column has wrong number of rows", expectedRows, sizes
 				.size());
@@ -125,7 +119,6 @@ public class FractalDimensionWrapperTest {
 			assertEquals("Count column has wrong number of rows", expectedRows, counts
 				.size());
 			for (int j = 0; j < expectedRows; j++) {
-//				assertEquals("Incorrect label", expectedLabels[i], label.get(j));
 				assertEquals("Incorrect log(count) value", expectedCounts[i][j], counts
 					.get(j), 1e-12);
 				assertEquals("Incorrect -log(box size) value", expectedSizes[j], sizes
@@ -140,9 +133,6 @@ public class FractalDimensionWrapperTest {
 		final Iterator<String> expectedHeaders = 
 				Stream.of("Fractal dimension", "R²").iterator();
 		final String imageName = "Image";
-//		final Iterator<String> expectedLabels = Stream.of(" Channel: 1, Time: 1",
-//			" Channel: 1, Time: 2", " Channel: 2, Time: 1", " Channel: 2, Time: 2")
-//			.map(imageName::concat).iterator();
 		final Iterator<Double> expectedDimensions = Stream.of(0.0,
 			1.4999999999999998, 1.4999999999999998, 0.0).iterator();
 		final Iterator<Double> expectedRSquares = Stream.of(Double.NaN,
@@ -164,8 +154,6 @@ public class FractalDimensionWrapperTest {
 			"Column has an incorrect number of rows", 4, column.size()));
 		table.stream().map(Column::getHeader).forEach(header -> assertEquals(
 			"Column has an incorrect header", header, expectedHeaders.next()));
-//		table.get.forEach(s -> assertEquals(
-//			"Label column has a wrong value", expectedLabels.next(), s));
 		table.get("Fractal dimension").forEach(dimension -> assertEquals(
 			"Fractal dimension column has a wrong value", expectedDimensions.next(),
 			dimension, 1e-12));

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -94,9 +94,9 @@ public class FractalDimensionWrapperTest {
 			.toArray();
 		final double[][] expectedCounts = { emptyCounts, cubeCounts, cubeCounts,
 			emptyCounts };
-		final String[] expectedLabels = { "Test Channel: 1, Time: 1",
-			"Test Channel: 2, Time: 1", "Test Channel: 1, Time: 2",
-			"Test Channel: 2, Time: 2" };
+//		final String[] expectedLabels = { "Test Channel: 1, Time: 1",
+//			"Test Channel: 2, Time: 1", "Test Channel: 1, Time: 2",
+//			"Test Channel: 2, Time: 2" };
 		final ImgPlus<BitType> imgPlus = createTestHyperStack("Test");
 
 		// EXECUTE
@@ -115,9 +115,9 @@ public class FractalDimensionWrapperTest {
 		for (int i = 0; i < pointTables.size(); i++) {
 			final GenericTable table = pointTables.get(i);
 			assertEquals("Table has wrong number of columns", 3, table.size());
-			final Column<String> label = (Column<String>) table.get("Label");
-			assertEquals("Label column has wrong number of rows", expectedRows, label
-				.size());
+//			final Column<String> label = (Column<String>) table.get("Label");
+//			assertEquals("Label column has wrong number of rows", expectedRows, label
+//				.size());
 			final DoubleColumn sizes = (DoubleColumn) table.get("-log(size)");
 			assertEquals("Size column has wrong number of rows", expectedRows, sizes
 				.size());
@@ -125,7 +125,7 @@ public class FractalDimensionWrapperTest {
 			assertEquals("Count column has wrong number of rows", expectedRows, counts
 				.size());
 			for (int j = 0; j < expectedRows; j++) {
-				assertEquals("Incorrect label", expectedLabels[i], label.get(j));
+//				assertEquals("Incorrect label", expectedLabels[i], label.get(j));
 				assertEquals("Incorrect log(count) value", expectedCounts[i][j], counts
 					.get(j), 1e-12);
 				assertEquals("Incorrect -log(box size) value", expectedSizes[j], sizes
@@ -137,12 +137,12 @@ public class FractalDimensionWrapperTest {
 	@Test
 	public void testResults() throws Exception {
 		// SETUP
-		final Iterator<String> expectedHeaders = Stream.of(SharedTable.LABEL_HEADER,
-			"Fractal dimension", "R²").iterator();
+		final Iterator<String> expectedHeaders = 
+				Stream.of("Fractal dimension", "R²").iterator();
 		final String imageName = "Image";
-		final Iterator<String> expectedLabels = Stream.of(" Channel: 1, Time: 1",
-			" Channel: 1, Time: 2", " Channel: 2, Time: 1", " Channel: 2, Time: 2")
-			.map(imageName::concat).iterator();
+//		final Iterator<String> expectedLabels = Stream.of(" Channel: 1, Time: 1",
+//			" Channel: 1, Time: 2", " Channel: 2, Time: 1", " Channel: 2, Time: 2")
+//			.map(imageName::concat).iterator();
 		final Iterator<Double> expectedDimensions = Stream.of(0.0,
 			1.4999999999999998, 1.4999999999999998, 0.0).iterator();
 		final Iterator<Double> expectedRSquares = Stream.of(Double.NaN,
@@ -157,20 +157,20 @@ public class FractalDimensionWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final Table<DefaultColumn<String>, String> table =
-			(Table<DefaultColumn<String>, String>) module.getOutput("resultsTable");
-		assertEquals("Wrong number of columns", 3, table.size());
+		final Table<DefaultColumn<Double>, Double> table =
+			(Table<DefaultColumn<Double>, Double>) module.getOutput("resultsTable");
+		assertEquals("Wrong number of columns", 2, table.size());
 		table.forEach(column -> assertEquals(
 			"Column has an incorrect number of rows", 4, column.size()));
 		table.stream().map(Column::getHeader).forEach(header -> assertEquals(
 			"Column has an incorrect header", header, expectedHeaders.next()));
-		table.get("Label").forEach(s -> assertEquals(
-			"Label column has a wrong value", expectedLabels.next(), s));
+//		table.get.forEach(s -> assertEquals(
+//			"Label column has a wrong value", expectedLabels.next(), s));
 		table.get("Fractal dimension").forEach(dimension -> assertEquals(
 			"Fractal dimension column has a wrong value", expectedDimensions.next(),
-			Double.parseDouble(dimension), 1e-12));
+			dimension, 1e-12));
 		table.get("R²").forEach(r2 -> assertEquals("R² column has a wrong value",
-			expectedRSquares.next(), Double.parseDouble(r2), 1e-12));
+			expectedRSquares.next(), r2, 1e-12));
 	}
 
 	@AfterClass

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -44,6 +44,7 @@ import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -84,7 +85,7 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testAngleResults() throws Exception {
 		// SETUP
-		final Predicate<String> nonEmpty = s -> !s.equals(SharedTable.EMPTY_CELL);
+		final Predicate<Double> nonEmpty = Objects::nonNull;
 		final URL resource = getClass().getClassLoader().getResource(
 			"test-skelly.zip");
 		assert resource != null;
@@ -98,16 +99,16 @@ public class IntertrabecularAngleWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("anglesTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("anglesTable");
 		assertNotNull(table);
-		assertEquals(3, table.size());
-		final DefaultColumn<String> threeColumn = table.get(1);
+		assertEquals(2, table.size());
+		final DefaultColumn<Double> threeColumn = table.get(0);
 		assertEquals("3", threeColumn.getHeader());
 		assertEquals(10, threeColumn.size());
 		assertEquals(3, threeColumn.stream().filter(nonEmpty).count());
 		assertEquals(2, threeColumn.stream().filter(nonEmpty).distinct().count());
-		final DefaultColumn<String> fiveColumn = table.get(2);
+		final DefaultColumn<Double> fiveColumn = table.get(1);
 		assertEquals("5", fiveColumn.getHeader());
 		assertEquals(10, fiveColumn.size());
 		assertEquals(10, fiveColumn.stream().filter(nonEmpty).count());
@@ -148,7 +149,7 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testMargins() throws Exception {
 		// SETUP
-		final Predicate<String> nonEmpty = s -> !s.equals(SharedTable.EMPTY_CELL);
+		final Predicate<Double> nonEmpty = s -> !s.equals(SharedTable.EMPTY_CELL);
 		final URL resource = getClass().getClassLoader().getResource(
 			"test-skelly.zip");
 		assert resource != null;
@@ -162,11 +163,11 @@ public class IntertrabecularAngleWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("anglesTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("anglesTable");
 		assertNotNull(table);
-		assertEquals(2, table.size());
-		final DefaultColumn<String> fiveColumn = table.get(1);
+		assertEquals(1, table.size());
+		final DefaultColumn<Double> fiveColumn = table.get(0);
 		assertEquals("5", fiveColumn.getHeader());
 		assertEquals(10, fiveColumn.size());
 		assertEquals(10, fiveColumn.stream().filter(nonEmpty).count());

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -284,18 +284,17 @@ public class SurfaceAreaWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Wrong number of columns", 2, table.size());
+		assertEquals("Wrong number of columns", 1, table.size());
 		for (int i = 0; i < 1; i++) {
-			final DefaultColumn<String> column = table.get(i + 1);
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals("A column has wrong number of rows", 4, column.size());
 			assertEquals("A column has an incorrect header", expectedHeaders[i],
 				column.getHeader());
 			for (int j = 0; j < column.size(); j++) {
-				assertEquals("Column has an incorrect value", expectedValues[j], Double
-					.parseDouble(column.get(j)), 1e-12);
+				assertEquals("Column has an incorrect value", expectedValues[j], column.get(j).doubleValue(), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -140,20 +140,20 @@ public class SurfaceFractionWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Wrong number of columns", 4, table.size());
+		assertEquals("Wrong number of columns", 3, table.size());
 		// Assert results
 		for (int i = 0; i < 3; i++) {
 			// Skip Label column
-			final DefaultColumn<String> column = table.get(i + 1);
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals("Wrong number of rows", 4, column.size());
 			assertEquals("Column has incorrect header", expectedHeaders[i], column
 				.getHeader());
 			for (int j = 0; j < expectedValues.length; j++) {
-				assertEquals("Incorrect value in table", expectedValues[i][j], Double
-					.parseDouble(column.get(j)), 1e-12);
+				assertEquals("Incorrect value in table", expectedValues[i][j], 
+						column.get(j).doubleValue(), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -175,9 +175,14 @@ public class ThicknessWrapperTest {
 		final String[] expectedHeaders = { "Tb.Th Mean (mm)", "Tb.Th Std Dev (mm)",
 			"Tb.Th Max (mm)", "Tb.Sp Mean (mm)", "Tb.Sp Std Dev (mm)",
 			"Tb.Sp Max (mm)" };
-		final String[][] expectedValues = { { "", "NaN" }, { "", "NaN" }, { "",
-			"NaN" }, { "10.392304420471191", "" }, { "0.0", "" }, {
-				"10.392304420471191", "" } };
+		final Double[][] expectedValues = {
+				{ new Double(Double.NaN), null },
+				{ new Double(Double.NaN), null },
+				{ new Double(Double.NaN), null },
+				{ null, new Double(10.392304420471191) },
+				{ null,  new Double(0.0) },
+				{ null, new Double(10.392304420471191) }
+				};
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
@@ -186,15 +191,16 @@ public class ThicknessWrapperTest {
 
 		// VERIFY
 		@SuppressWarnings("unchecked")
-		final List<DefaultColumn<String>> table =
-			(List<DefaultColumn<String>>) module.getOutput("resultsTable");
+		final List<DefaultColumn<Double>> table =
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
-		assertEquals("Results table has wrong number of columns", 7, table.size());
+		assertEquals("Results table has wrong number of columns", 6, table.size());
 		for (int i = 0; i < 6; i++) {
-			final DefaultColumn<String> column = table.get(i + 1);
+			final DefaultColumn<Double> column = table.get(i);
 			assertEquals(expectedHeaders[i], column.getHeader());
+			assertEquals("Results table has wrong number of rows", 2, column.size());
 			for (int j = 0; j < 2; j++) {
-				assertEquals("Column has an incorrect value", expectedValues[i][j],
+				assertEquals("Cell at i="+i+", j="+j+" has an incorrect value", expectedValues[i][j],
 					column.getValue(j));
 			}
 		}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
@@ -47,7 +47,7 @@ public class SharedTableCleanerTest {
 	@Test
 	public void testRun() throws Exception {
 		// SETUP
-		SharedTable.add("Label", "Header", "Value");
+		SharedTable.add("Label", "Header", 0.0);
 		assertTrue("Sanity check failed, no data in SharedTable", SharedTable
 			.hasData());
 


### PR DESCRIPTION
This PR addresses:

#125 Storing result table values as Double rather than String
Using the rowHeader special column rather than a 'Label' column to store image titles
#117 Filling the table from the bottom when duplicate image titles are present in the rowHeaders
#124 No more alphabetical sorting