### PR TITLE
Fix issue 122

### DIFF
--- a/Modern/utilities/src/main/java/org/bonej/utilities/AxisUtils.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/AxisUtils.java
@@ -71,19 +71,21 @@ public final class AxisUtils {
 	 * @param space an n-dimensional space with calibrated axes.
 	 * @param <S> type of the space.
 	 * @param unitService an {@link UnitService} to convert axis calibrations.
-	 * @return an optional with the unit of spatial calibration. It's empty if the
-	 *         space == null, there are no spatial axes, or there's no conversion
-	 *         between their units. The Optional contains an empty string none of
-	 *         the calibrations have a unit.
+	 * @return an optional with the common unit of spatial calibrations. It's
+	 *         {@link Optional#empty()} if there's no conversion between the
+	 *         units. The Optional contains an empty string if none of the axes
+	 *         have a unit.
+	 * @throws IllegalArgumentException if space has no spatial axes
 	 */
-	public static <S extends AnnotatedSpace<C>, C extends CalibratedAxis> Optional<String>
-		getSpatialUnit(final S space, final UnitService unitService)
+	public static <S extends AnnotatedSpace<C>, C extends CalibratedAxis>
+		Optional<String> getSpatialUnit(final S space,
+			final UnitService unitService) throws IllegalArgumentException
 	{
-		if (space == null || !hasSpatialDimensions(space)) {
-			return Optional.empty();
+		if (!hasSpatialDimensions(space)) {
+			throw new IllegalArgumentException("Space has no spatial axes");
 		}
 		if (!isUnitsConvertible(space, unitService)) {
-			return Optional.of("");
+			return Optional.empty();
 		}
 		final String unit = space.axis(0).unit();
 		return unit == null ? Optional.of("") : Optional.of(unit);
@@ -152,8 +154,7 @@ public final class AxisUtils {
 	 * @param tolerance tolerance for anisotropy in scaling
 	 * @param unitService service to convert between units of calibration
 	 * @return true if spatial calibrations are isotropic within tolerance
-	 * @throws IllegalArgumentException if tolerance is negative or NaN, or space
-	 *           has no spatial axes.
+	 * @throws IllegalArgumentException if tolerance is negative or NaN
 	 */
 	public static <S extends AnnotatedSpace<A>, A extends CalibratedAxis> boolean
 		isSpatialCalibrationsIsotropic(final S space, final double tolerance,

--- a/Modern/utilities/src/main/java/org/bonej/utilities/AxisUtils.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/AxisUtils.java
@@ -154,7 +154,8 @@ public final class AxisUtils {
 	 * @param tolerance tolerance for anisotropy in scaling
 	 * @param unitService service to convert between units of calibration
 	 * @return true if spatial calibrations are isotropic within tolerance
-	 * @throws IllegalArgumentException if tolerance is negative or NaN
+	 * @throws IllegalArgumentException if tolerance is negative or NaN, or
+	 *           calibration units cannot be converted
 	 */
 	public static <S extends AnnotatedSpace<A>, A extends CalibratedAxis> boolean
 		isSpatialCalibrationsIsotropic(final S space, final double tolerance,
@@ -168,7 +169,8 @@ public final class AxisUtils {
 		}
 		final Optional<String> commonUnit = getSpatialUnit(space, unitService);
 		if (!commonUnit.isPresent()) {
-			return false;
+			throw new IllegalArgumentException(
+				"Isotropy cannot be determined: units of spatial calibrations are inconvertible");
 		}
 		final String outputUnit = commonUnit.get();
 		final double[] scales = spatialAxisStream(space).mapToDouble(

--- a/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
@@ -66,7 +66,8 @@ public final class ElementUtil {
 	 * @param unitService needed to convert between units of different
 	 *          calibrations.
 	 * @return Calibrated size of a spatial element, or Double.NaN if space ==
-	 *         null, has nonlinear axes, or calibration units don't match.
+	 *         has nonlinear axes, or calibrations don't have a common unit.
+	 * @see AxisUtils#getSpatialUnit(AnnotatedSpace, UnitService)
 	 */
 	public static <T extends AnnotatedSpace<CalibratedAxis>> double
 		calibratedSpatialElementSize(final T space, final UnitService unitService)

--- a/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
@@ -65,8 +65,8 @@ public final class ElementUtil {
 	 * @param <T> type of the space.
 	 * @param unitService needed to convert between units of different
 	 *          calibrations.
-	 * @return Calibrated size of a spatial element, or Double.NaN if space ==
-	 *         has nonlinear axes, or calibrations don't have a common unit.
+	 * @return Calibrated size of a spatial element, or Double.NaN if space == has
+	 *         nonlinear axes, or calibrations don't have a common unit.
 	 * @see AxisUtils#getSpatialUnit(AnnotatedSpace, UnitService)
 	 */
 	public static <T extends AnnotatedSpace<CalibratedAxis>> double

--- a/Modern/utilities/src/main/java/org/bonej/utilities/Streamers.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/Streamers.java
@@ -23,14 +23,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.utilities;
 
-import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
-import java.util.stream.StreamSupport;
 
 import net.imagej.axis.TypedAxis;
 import net.imagej.space.AnnotatedSpace;
-import net.imglib2.type.numeric.RealType;
 
 /**
  * Utility functions to generate streams from various ImageJ2 collections
@@ -47,16 +44,11 @@ public final class Streamers {
 	 * @param space an N-dimensional space.
 	 * @param <S> type of the space.
 	 * @param <A> type of the axes.
-	 * @return a Stream of the axes. An empty stream if space == null or space has
-	 *         no axes.
+	 * @return a Stream of the axes. An empty stream if space has no axes.
 	 */
 	public static <S extends AnnotatedSpace<A>, A extends TypedAxis> Stream<A>
 		axisStream(final S space)
 	{
-		if (space == null) {
-			return Stream.empty();
-		}
-
 		final int dimensions = space.numDimensions();
 		final Builder<A> builder = Stream.builder();
 		for (int d = 0; d < dimensions; d++) {

--- a/Modern/utilities/src/main/java/org/bonej/utilities/Streamers.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/Streamers.java
@@ -64,7 +64,7 @@ public final class Streamers {
 	 * @param space an N-dimensional space.
 	 * @param <S> type of the space.
 	 * @param <A> type of the axes.
-	 * @return a Stream of spatial axes. An empty stream if space == null.
+	 * @return a Stream of spatial axes. An empty stream space has no spatial axes.
 	 */
 	public static <S extends AnnotatedSpace<A>, A extends TypedAxis> Stream<A>
 		spatialAxisStream(final S space)

--- a/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
@@ -41,7 +41,9 @@ import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.real.DoubleType;
 
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.scijava.Contextual;
 
 /**
@@ -54,6 +56,109 @@ public class AxisUtilsTest {
 	private static final Contextual IMAGE_J = new ImageJ();
 	private static final UnitService unitService = IMAGE_J.context().getService(
 		UnitService.class);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void isSpatialCalibrationsIsotropicThrowsIAENanTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Tolerance cannot be NaN");
+
+		// EXECUTE
+		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, Double.NaN, unitService);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicThrowsIAENegativeTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Tolerance cannot be negative");
+
+		// EXECUTE
+		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, -1.0, unitService);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropic() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicDifferentUnits() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "cm", 0.1);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicAnisotropicBeyondTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.06);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.05, unitService);
+
+		// VERIFY
+		assertFalse(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicAnisotropicWithinTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.05);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.05, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
 
 	@Test
 	public void testCountSpatialDimensions() {

--- a/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
@@ -61,14 +61,103 @@ public class AxisUtilsTest {
 	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
+	public void isSpatialCalibrationsIsotropic() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus,
+			0.0, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicAnisotropicBeyondTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.06);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus,
+			0.05, unitService);
+
+		// VERIFY
+		assertFalse(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicAnisotropicWithinTolerance() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.05);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus,
+			0.05, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicDifferentUnits() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "cm", 0.1);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
+
+		// EXECUTE
+		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus,
+			0.0, unitService);
+
+		// VERIFY
+		assertTrue(result);
+	}
+
+	@Test
+	public void isSpatialCalibrationsIsotropicThrowsIAEInconvertibleUnits() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "kg", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage(
+			"Isotropy cannot be determined: units of spatial calibrations are inconvertible");
+
+		// EXECUTE
+		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
+	}
+
+	@Test
 	public void isSpatialCalibrationsIsotropicThrowsIAENanTolerance() {
 		// SETUP
 		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
 		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("Tolerance cannot be NaN");
 
@@ -83,97 +172,13 @@ public class AxisUtilsTest {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
 		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis, yAxis,
+			zAxis);
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("Tolerance cannot be negative");
 
 		// EXECUTE
 		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, -1.0, unitService);
-	}
-
-	@Test
-	public void isSpatialCalibrationsIsotropic() {
-		// SETUP
-		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
-
-		// EXECUTE
-		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
-
-		// VERIFY
-		assertTrue(result);
-	}
-
-	@Test
-	public void isSpatialCalibrationsIsotropicDifferentUnits() {
-		// SETUP
-		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "cm", 0.1);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
-
-		// EXECUTE
-		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
-
-		// VERIFY
-		assertTrue(result);
-	}
-
-	@Test
-	public void isSpatialCalibrationsIsotropicAnisotropicBeyondTolerance() {
-		// SETUP
-		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.06);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
-
-		// EXECUTE
-		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.05, unitService);
-
-		// VERIFY
-		assertFalse(result);
-	}
-
-	@Test
-	public void isSpatialCalibrationsIsotropicAnisotropicWithinTolerance() {
-		// SETUP
-		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.05);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "mm", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
-
-		// EXECUTE
-		final boolean result = AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.05, unitService);
-
-		// VERIFY
-		assertTrue(result);
-	}
-
-	@Test
-	public void isSpatialCalibrationsIsotropicThrowsIAEInconvertibleUnits() {
-		// SETUP
-		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "kg", 1.0);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
-				yAxis, zAxis);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("Isotropy cannot be determined: units of spatial calibrations are inconvertible");
-
-		// EXECUTE
-		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
 	}
 
 	@Test

--- a/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
@@ -177,13 +177,6 @@ public class AxisUtilsTest {
 	}
 
 	@Test
-	public void testCountSpatialDimensionsNullSpace() {
-		final long result = AxisUtils.countSpatialDimensions(null);
-
-		assertEquals("A null space should contain zero dimensions", 0, result);
-	}
-
-	@Test
 	public void testGetSpatialUnit() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "µm", 1.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 5.0);
@@ -248,13 +241,6 @@ public class AxisUtilsTest {
 	}
 
 	@Test
-	public void testHasChannelDimensionsFalseIfSpaceNull() {
-		final boolean result = AxisUtils.hasChannelDimensions(null);
-
-		assertFalse("Null image should not have a channel dimension", result);
-	}
-
-	@Test
 	public void testHasSpatialDimensions() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X);
 		final DefaultLinearAxis tAxis = new DefaultLinearAxis(Axes.TIME);
@@ -265,13 +251,6 @@ public class AxisUtilsTest {
 		final boolean result = AxisUtils.hasTimeDimensions(imgPlus);
 
 		assertTrue("Should be true when image has spatial dimensions", result);
-	}
-
-	@Test
-	public void testHasSpatialDimensionsFalseIfSpaceNull() {
-		final boolean result = AxisUtils.hasSpatialDimensions(null);
-
-		assertFalse("Null image should not have a time dimension", result);
 	}
 
 	@Test
@@ -286,13 +265,6 @@ public class AxisUtilsTest {
 		final boolean result = AxisUtils.hasTimeDimensions(imgPlus);
 
 		assertTrue("Should be true when image has time dimensions", result);
-	}
-
-	@Test
-	public void testHasTimeDimensionsFalseIfSpaceNull() {
-		final boolean result = AxisUtils.hasTimeDimensions(null);
-
-		assertFalse("Null image should not have a time dimension", result);
 	}
 
 	@AfterClass

--- a/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
@@ -161,6 +161,22 @@ public class AxisUtilsTest {
 	}
 
 	@Test
+	public void isSpatialCalibrationsIsotropicThrowsIAEInconvertibleUnits() {
+		// SETUP
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm", 1.0);
+		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 1.0);
+		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, "kg", 1.0);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", xAxis,
+				yAxis, zAxis);
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Isotropy cannot be determined: units of spatial calibrations are inconvertible");
+
+		// EXECUTE
+		AxisUtils.isSpatialCalibrationsIsotropic(imgPlus, 0.0, unitService);
+	}
+
+	@Test
 	public void testGetSpatialUnit() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "µm", 1.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 5.0);

--- a/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/AxisUtilsTest.java
@@ -161,22 +161,6 @@ public class AxisUtilsTest {
 	}
 
 	@Test
-	public void testCountSpatialDimensions() {
-		// Create a test image
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y);
-		final DefaultLinearAxis channelAxis = new DefaultLinearAxis(Axes.CHANNEL);
-		final long[] dimensions = { 10, 10, 3 };
-		final Img<DoubleType> img = ArrayImgs.doubles(dimensions);
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis, channelAxis);
-
-		final long result = AxisUtils.countSpatialDimensions(imgPlus);
-
-		assertEquals("Wrong number of spatial dimensions", 2, result);
-	}
-
-	@Test
 	public void testGetSpatialUnit() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "µm", 1.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", 5.0);
@@ -221,8 +205,7 @@ public class AxisUtilsTest {
 			final Optional<String> result = AxisUtils.getSpatialUnit(imgPlus,
 				unitService);
 
-			assertTrue(result.isPresent());
-			assertTrue("Unit should be empty", result.get().isEmpty());
+			assertFalse(result.isPresent());
 		}
 	}
 

--- a/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
@@ -88,19 +88,6 @@ public class ElementUtilTest {
 	}
 
 	@Test
-	public void testCalibratedSpatialElementSizeNoSpatialAxes() {
-		final DefaultLinearAxis cAxis = new DefaultLinearAxis(Axes.CHANNEL);
-		final Img<DoubleType> img = IMAGE_J.op().create().img(new int[] { 3 });
-		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", cAxis);
-
-		final double elementSize = ElementUtil.calibratedSpatialElementSize(imgPlus,
-			unitService);
-
-		assertTrue("Element size should be NaN when there are no spatial axes",
-			Double.isNaN(elementSize));
-	}
-
-	@Test
 	public void testCalibratedSpatialElementSizeNoUnits() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, 20.0);
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, 4.0);
@@ -131,14 +118,6 @@ public class ElementUtilTest {
 	}
 
 	@Test
-	public void testCalibratedSpatialElementSizeNullSpace() {
-		final double result = ElementUtil.calibratedSpatialElementSize(null,
-			unitService);
-
-		assertTrue("Size should be NaN when space is null", Double.isNaN(result));
-	}
-
-	@Test
 	public void testCalibratedSpatialElementSizeUnitsInconvertible() {
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "cm");
 		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "");
@@ -149,8 +128,7 @@ public class ElementUtilTest {
 		final double result = ElementUtil.calibratedSpatialElementSize(imgPlus,
 			unitService);
 
-		assertEquals("Size should be 1.0 if unit inconvertible", 1.0, result,
-			1e-12);
+		assertTrue(Double.isNaN(result));
 	}
 
 	@Test

--- a/Modern/utilities/src/test/java/org/bonej/utilities/StreamersTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/StreamersTest.java
@@ -24,18 +24,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.bonej.utilities;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
+import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imagej.axis.TypedAxis;
 import net.imglib2.img.Img;
@@ -71,6 +69,18 @@ public class StreamersTest {
 			0));
 		assertEquals("Axes in the stream are in wrong order", Axes.Y, result.get(
 			1));
+	}
+
+	@Test
+	public void testSpatialAxisStreamNoSpatialAxes() {
+		final Img<DoubleType> img = ArrayImgs.doubles(10, 10, 10);
+		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "", new AxisType[] {
+			Axes.unknown(), Axes.unknown(), Axes.unknown() });
+
+		final Stream<CalibratedAxis> result = Streamers.spatialAxisStream(imgPlus);
+
+		assertNotNull(result);
+		assertEquals(0, result.count());
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/Modern/utilities/src/test/java/org/bonej/utilities/StreamersTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/StreamersTest.java
@@ -73,11 +73,8 @@ public class StreamersTest {
 			1));
 	}
 
-	@Test
-	public void testSpatialAxisStreamReturnsEmptyIfSpaceNull() {
-		final Stream<TypedAxis> result = Streamers.spatialAxisStream(null);
-
-		assertNotNull("Stream should not be null", result);
-		assertFalse("Stream should be empty", result.findAny().isPresent());
+	@Test(expected = NullPointerException.class)
+	public void testSpatialAxisStreamThrowsNPEIfSpaceNull() {
+		Streamers.spatialAxisStream(null);
 	}
 }

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -25,9 +25,7 @@ package org.bonej.wrapperPlugins;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.generate;
-import static org.bonej.utilities.AxisUtils.getSpatialUnit;
 import static org.bonej.utilities.AxisUtils.isSpatialCalibrationsIsotropic;
-import static org.bonej.utilities.Streamers.spatialAxisStream;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
 import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
@@ -253,17 +251,6 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			cancel("The plug-in was interrupted");
 		}
 		return null;
-	}
-
-	// TODO Refactor into a static utility method with unit tests
-	private boolean isCalibrationIsotropic() {
-		final Optional<String> commonUnit = getSpatialUnit(inputImage, unitService);
-		if (!commonUnit.isPresent()) {
-			return false;
-		}
-		final String unit = commonUnit.get();
-		return spatialAxisStream(inputImage).map(axis -> unitService.value(axis
-			.averageScale(0, 1), axis.unit(), unit)).distinct().count() == 1;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -26,6 +26,7 @@ package org.bonej.wrapperPlugins;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.generate;
 import static org.bonej.utilities.AxisUtils.getSpatialUnit;
+import static org.bonej.utilities.AxisUtils.isSpatialCalibrationsIsotropic;
 import static org.bonej.utilities.Streamers.spatialAxisStream;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_3D_IMAGE;
 import static org.bonej.wrapperPlugins.CommonMessages.NOT_BINARY;
@@ -343,7 +344,9 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			cancel(NOT_BINARY);
 			return;
 		}
-		if (!isCalibrationIsotropic() && !calibrationWarned) {
+		if (!isSpatialCalibrationsIsotropic(inputImage, 0.01, unitService) &&
+			!calibrationWarned)
+		{
 			final Result result = uiService.showDialog(
 				"The voxels in the image are anisotropic, which may affect results. Continue anyway?",
 				WARNING_MESSAGE, OK_CANCEL_OPTION);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -231,6 +231,20 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 		return quadricToEllipsoidOp.calculate(quadric);
 	}
 
+	@SuppressWarnings("unchecked")
+	private void matchOps(final Subspace<BitType> subspace) {
+		milOp = Functions.binary(opService, MILPlane.class, Vector3d.class,
+			subspace.interval, new AxisAngle4d(), lines, samplingIncrement);
+		final List<Vector3d> tmpPoints = generate(Vector3d::new).limit(
+			SolveQuadricEq.QUADRIC_TERMS).collect(toList());
+		solveQuadricOp = Functions.unary(opService, SolveQuadricEq.class,
+			Matrix4d.class, tmpPoints);
+		final Matrix4d matchingMock = new Matrix4d();
+		matchingMock.setIdentity();
+		quadricToEllipsoidOp = (UnaryFunctionOp) Functions.unary(opService,
+			QuadricToEllipsoid.class, Optional.class, matchingMock);
+	}
+
 	private Ellipsoid milEllipsoid(final Subspace<BitType> subspace) {
 		final List<Vector3d> pointCloud;
 		try {
@@ -251,20 +265,6 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			cancel("The plug-in was interrupted");
 		}
 		return null;
-	}
-
-	@SuppressWarnings("unchecked")
-	private void matchOps(final Subspace<BitType> subspace) {
-		milOp = Functions.binary(opService, MILPlane.class, Vector3d.class,
-			subspace.interval, new AxisAngle4d(), lines, samplingIncrement);
-		final List<Vector3d> tmpPoints = generate(Vector3d::new).limit(
-			SolveQuadricEq.QUADRIC_TERMS).collect(toList());
-		solveQuadricOp = Functions.unary(opService, SolveQuadricEq.class,
-			Matrix4d.class, tmpPoints);
-		final Matrix4d matchingMock = new Matrix4d();
-		matchingMock.setIdentity();
-		quadricToEllipsoidOp = (UnaryFunctionOp) Functions.unary(opService, QuadricToEllipsoid.class,
-			Optional.class, matchingMock);
 	}
 
 	private List<Vector3d> runDirectionsInParallel(

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -134,7 +134,7 @@ public class AnisotropyWrapperTest {
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(AnisotropyWrapper.class,
-			true, "inputImage", imgPlus, "lines", 1, "directions", 1).get();
+			true, "inputImage", imgPlus, "lines", 10, "directions", 10).get();
 
 		// VERIFY
 		assertTrue(module.isCanceled());

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
@@ -212,13 +212,6 @@ public class ResultUtilsTest {
 	}
 
 	@Test
-	public void testGetUnitHeaderReturnEmptyIfImageNull() {
-		final String result = ResultUtils.getUnitHeader(null, unitService, '³');
-
-		assertTrue("Unit header should be empty", result.isEmpty());
-	}
-
-	@Test
 	public void testGetUnitHeaderReturnPixelIfDefaultUnitPixel() {
 		final String unit = "pixel";
 		final String expected = "(" + unit + "³)";


### PR DESCRIPTION
* Adds utility method `AxisUtils.isSpatialCalibrationsIsotropic`
* `AnisotropyWrapper` now calls the above instead of its private method
* Fixes exception behaviour in `AxisUtils` methods
* Fixes issue #122 
* Updates tests
* Formats code in affected files
