### PR TITLE
Return a copy of SharedTable

### DIFF
--- a/IntegrationTestLogs/SharedTable.txt
+++ b/IntegrationTestLogs/SharedTable.txt
@@ -1,0 +1,22 @@
+Integration tests for SharedTable in org.bonej.utilities.SharedTable
+
+
+Case 1
+=======================================================================
+Only one table opens
+=======================================================================
+Steps
+-----------------------------------------------------------------------
+ 1. Open "bat-cochlea-volume.tif" (File>Open Samples>Bat Cochlea Volume)
+ 2. Run Plugins>BoneJ>Fraction>Area/volume fraction
+ 3. Run Plugins>BoneJ>Fractal Dimension
+    - Check option "Automatic Parameters"
+    - Uncheck option "Show points"
+
+Expected result
+-----------------------------------------------------------------------
+User sees one table with results from both plug-ins
+(e.g. "Bone volume" and "Fractal dimension")
+
+Completed September 3 2018 Richard Domander
+-----------------------------------------------------------------------

--- a/IntegrationTestLogs/SharedTableCleaner.txt
+++ b/IntegrationTestLogs/SharedTableCleaner.txt
@@ -8,12 +8,12 @@ Plugin closes the results table
 Steps
 -----------------------------------------------------------------------
  1. Open "bat-cochlea-volume.tif" (File>Open Samples>Bat Cochlea Volume)
- 2. Run Plugins>BoneJ>Fraction>Volume/area fraction
+ 2. Run Plugins>BoneJ>Fraction>Area/volume fraction
  3. Run Plugins>BoneJ>Table>Clear BoneJ results
 
 Expected result
 -----------------------------------------------------------------------
 The table window should close
 
-Completed May 16 2017 Richard Domander
+Completed September 3 2018 Richard Domander
 -----------------------------------------------------------------------

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -154,8 +154,7 @@ public final class SharedTable {
 
 	@SuppressWarnings("unchecked")
 	private static Table<DefaultColumn<Double>, Double> createTable() {
-		final Table newTable = new DefaultGenericTable();
-		return newTable;
+		return (Table) new DefaultGenericTable();
 	}
 
 	private static void fillEmptyColumn(final int columnIndex) {

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -146,7 +146,8 @@ public final class SharedTable {
 			publicCopy.setColumnCount(0);
 		}
 		table.forEach(publicCopy::add);
-		// Just calling publicCopy::add is not enough to update size info (ThicknessWrapperTests fail)
+		// Just calling publicCopy::add is not enough to update size info
+		// (ThicknessWrapperTests fail)
 		publicCopy.setRowCount(table.getRowCount());
 		publicCopy.setColumnCount(table.getColumnCount());
 		for (int i = 0; i < table.getRowCount(); i++) {

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -185,7 +185,7 @@ public final class SharedTable {
 			if (table.getRowHeader(i).equals(label)) {
 				//check whether there is not already a value in columnIndex
 				final Double cell = table.get(columnIndex, i); 
-				if (cell == EMPTY_CELL) {
+				if (Objects.equals(cell, EMPTY_CELL)) {
 					//add the value to the row and column
 					table.set(columnIndex, i, value);
 					return;

--- a/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/SharedTable.java
@@ -42,13 +42,14 @@ import org.scijava.util.StringUtils;
  * e.g. "Volume"</li>
  * <li>If there are no rows with the given label, then add a new row</li>
  * <li>If there are rows with the given label, but there is not a column with
- * the given heading, then append a column, and set its value on the last row with
- * the label.</li>
+ * the given heading, then append a column, and set its value on the last row
+ * with the label.</li>
  * <li>If there are rows with the given label, and there's a column with the
  * given heading, then find the last empty cell (equals {@link #EMPTY_CELL}),
  * and add the new value there. If there are no empty cells, then append a new
  * row.</li>
- * <li>Labels and columns are kept in the order in which they were produced.</li>
+ * <li>Labels and columns are kept in the order in which they were
+ * produced.</li>
  * </ol>
  *
  * @author Richard Domander
@@ -62,6 +63,8 @@ public final class SharedTable {
 	 * The table uses Double values. Empty cells are indicated by null
 	 */
 	private static Table<DefaultColumn<Double>, Double> table = createTable();
+
+	private static Table<DefaultColumn<Double>, Double> publicCopy;
 
 	private SharedTable() {}
 
@@ -121,16 +124,40 @@ public final class SharedTable {
 	}
 
 	/**
-	 * Gets the shared {@link Table} instance.
+	 * Gets a copy of the singleton {@link Table}.
+	 * <p>
+	 * Returns the same copy instance on every call. However, the contents of the
+	 * copy table are always cleared and copied from the actual table. That is, if
+	 * you've modified the copy after the previous call, those modifications are
+	 * lost.
+	 * </p>
 	 *
-	 * @return the singleton table.
+	 * @return the persistent copy instance.
 	 */
 	public static Table<DefaultColumn<Double>, Double> getTable() {
-		return table;
+		if (publicCopy == null) {
+			publicCopy = createTable();
+		}
+		else {
+			// Calling publicCopy.clear() would be simpler, but it breaks the tests of
+			// the class. However, the tests fail only when run together, individually
+			// they pass.
+			publicCopy.setRowCount(0);
+			publicCopy.setColumnCount(0);
+		}
+		table.forEach(publicCopy::add);
+		// Just calling publicCopy::add is not enough to update size info (ThicknessWrapperTests fail)
+		publicCopy.setRowCount(table.getRowCount());
+		publicCopy.setColumnCount(table.getColumnCount());
+		for (int i = 0; i < table.getRowCount(); i++) {
+			publicCopy.setRowHeader(i, table.getRowHeader(i));
+		}
+		return publicCopy;
 	}
 
 	public static boolean hasData() {
-		return table.stream().flatMap(Collection::stream).anyMatch(Objects::nonNull);
+		return table.stream().flatMap(Collection::stream).anyMatch(
+			Objects::nonNull);
 	}
 
 	/** Initializes the table into a new empty table */
@@ -140,16 +167,16 @@ public final class SharedTable {
 
 	// region -- Helper methods --
 
-	private static int headerIndex(final String header) {
-		final int cols = table.getColumnCount();
-		return IntStream.range(0, cols).filter(i -> table.get(i).getHeader().equals(
-			header)).findFirst().orElse(cols);
-	}
-
 	private static void appendEmptyColumn(final String header) {
 		table.appendColumn(header);
 		final int lastColumn = table.getColumnCount() - 1;
 		fillEmptyColumn(lastColumn);
+	}
+
+	private static void appendEmptyRow(final String label) {
+		table.appendRow(label);
+		final int lastRow = table.getRowCount() - 1;
+		fillEmptyRow(label, lastRow);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -162,37 +189,37 @@ public final class SharedTable {
 		IntStream.range(0, column.size()).forEach(i -> column.set(i, EMPTY_CELL));
 	}
 
-	private static void appendEmptyRow(final String label) {
-		table.appendRow(label);
-		final int lastRow = table.getRowCount() - 1;
-		fillEmptyRow(label, lastRow);
-	}
-	
 	private static void fillEmptyRow(final String label, final int row) {
 		table.setRowHeader(row, label);
 		final int columns = table.getColumnCount();
 		IntStream.range(0, columns).forEach(column -> table.set(column, row,
 			EMPTY_CELL));
 	}
-	
+
+	private static int headerIndex(final String header) {
+		final int cols = table.getColumnCount();
+		return IntStream.range(0, cols).filter(i -> table.get(i).getHeader().equals(
+			header)).findFirst().orElse(cols);
+	}
+
 	private static void insertIntoNextFreeRow(final String label,
 		final int columnIndex, final Double value)
 	{
 		final int rows = table.getRowCount();
-		//iterate up the table from the bottom
-		for (int i = rows-1; i >=0; i--) {
-			//if we find a row with the same label
+		// iterate up the table from the bottom
+		for (int i = rows - 1; i >= 0; i--) {
+			// if we find a row with the same label
 			if (table.getRowHeader(i).equals(label)) {
-				//check whether there is not already a value in columnIndex
-				final Double cell = table.get(columnIndex, i); 
+				// check whether there is not already a value in columnIndex
+				final Double cell = table.get(columnIndex, i);
 				if (Objects.equals(cell, EMPTY_CELL)) {
-					//add the value to the row and column
+					// add the value to the row and column
 					table.set(columnIndex, i, value);
 					return;
 				}
 			}
 		}
-		//we didn't find the label in the table so make a new row
+		// we didn't find the label in the table so make a new row
 		appendEmptyRow(label);
 		table.set(columnIndex, rows, value);
 	}

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -26,14 +26,12 @@ package org.bonej.utilities;
 import static org.bonej.utilities.SharedTable.EMPTY_CELL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Objects;
 
 import net.imagej.table.DefaultColumn;
-import net.imagej.table.DefaultGenericTable;
 import net.imagej.table.Table;
 
 import org.junit.After;

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -26,11 +26,14 @@ package org.bonej.utilities;
 import static org.bonej.utilities.SharedTable.EMPTY_CELL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Objects;
 
 import net.imagej.table.DefaultColumn;
+import net.imagej.table.DefaultGenericTable;
 import net.imagej.table.Table;
 
 import org.junit.After;
@@ -209,5 +212,26 @@ public class SharedTableTest {
 		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
+	}
+
+	@Test
+	public void testGetTableCopyPersists() {
+		final Table instance1 = SharedTable.getTable();
+		final Table instance2 = SharedTable.getTable();
+
+		assertSame(instance1, instance2);
+	}
+
+	@Test
+	public void testGetTableCopyDataCleared() {
+		final Table<DefaultColumn<Double>, Double> copy = SharedTable.getTable();
+		copy.appendRow();
+		copy.appendColumn();
+		copy.set(0, 0, 13.0);
+		final Table<DefaultColumn<Double>, Double> copy2 = SharedTable.getTable();
+
+		assertEquals(0, copy2.size());
+		assertEquals(0, copy2.getColumnCount());
+		assertEquals(0, copy2.getRowCount());
 	}
 }

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -82,7 +82,7 @@ public class SharedTableTest {
 		assertEquals("Cell should be empty", EMPTY_CELL, column1.get(0));
 		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(Objects::isNull).count());
 		final DefaultColumn<Double> column2 = table.get(header2);
-		assertEquals("Cell contains wrong value", 3.0, column2.get(1).doubleValue(), 1e-12);
+		assertEquals("Cell contains wrong value", 3.0, column2.get(1), 1e-12);
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
 			s -> s == null).count());
 		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
@@ -138,7 +138,7 @@ public class SharedTableTest {
 		assertEquals(1, table.getColumnCount());
 		assertEquals(header, table.get(0).getHeader());
 		assertEquals(label, table.getRowHeader(0));
-		assertEquals(1.0, table.get(header).get(0).doubleValue(), 1e-12);
+		assertEquals(1.0, table.get(header).get(0), 1e-12);
 	}
 
 	@Test
@@ -153,9 +153,9 @@ public class SharedTableTest {
 			"Adding data to the same column, to the row with the same label, should create a new row",
 			2, table.getRowCount());
 		assertEquals("Values in wrong order, older should be first", 1, table.get(
-			"Run").get(0).doubleValue(), 1e-12);
+				"Run").get(0), 1e-12);
 		assertEquals("Values in wrong order, older should be first", 2, table.get(
-			"Run").get(1).doubleValue(), 1e-12);
+				"Run").get(1), 1e-12);
 	}
 
 	@Test

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -82,7 +82,7 @@ public class SharedTableTest {
 		final DefaultColumn<Double> column2 = table.get(header2);
 		assertEquals("Cell contains wrong value", 3.0, column2.get(1), 1e-12);
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
-			s -> s == null).count());
+				Objects::isNull).count());
 		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
 	}
 

--- a/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/SharedTableTest.java
@@ -78,11 +78,12 @@ public class SharedTableTest {
 		assertEquals("Wrong number of rows", 3, table.getRowCount());
 		final DefaultColumn<Double> column1 = table.get(header1);
 		assertEquals("Cell should be empty", EMPTY_CELL, column1.get(0));
-		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(Objects::isNull).count());
+		assertEquals("Wrong number of empty cells", 1, column1.stream().filter(
+			Objects::isNull).count());
 		final DefaultColumn<Double> column2 = table.get(header2);
 		assertEquals("Cell contains wrong value", 3.0, column2.get(1), 1e-12);
 		assertEquals("Wrong number of empty cells", 0, column2.stream().filter(
-				Objects::isNull).count());
+			Objects::isNull).count());
 		assertEquals("Label on the wrong row", 0, table.getRowIndex(labelB));
 	}
 
@@ -140,20 +141,24 @@ public class SharedTableTest {
 	}
 
 	@Test
-	public void testRepeatingHeaderAndLabelAddsARow() {
-		SharedTable.add("Image", "Value", 1.0);
-		SharedTable.add("Image", "Run", 1);
-		SharedTable.add("Image", "Value", 1.0);
-		SharedTable.add("Image", "Run", 2);
+	public void testGetTableCopyDataCleared() {
+		final Table<DefaultColumn<Double>, Double> copy = SharedTable.getTable();
+		copy.appendRow();
+		copy.appendColumn();
+		copy.set(0, 0, 13.0);
+		final Table<DefaultColumn<Double>, Double> copy2 = SharedTable.getTable();
 
-		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
-		assertEquals(
-			"Adding data to the same column, to the row with the same label, should create a new row",
-			2, table.getRowCount());
-		assertEquals("Values in wrong order, older should be first", 1, table.get(
-				"Run").get(0), 1e-12);
-		assertEquals("Values in wrong order, older should be first", 2, table.get(
-				"Run").get(1), 1e-12);
+		assertEquals(0, copy2.size());
+		assertEquals(0, copy2.getColumnCount());
+		assertEquals(0, copy2.getRowCount());
+	}
+
+	@Test
+	public void testGetTableCopyPersists() {
+		final Table instance1 = SharedTable.getTable();
+		final Table instance2 = SharedTable.getTable();
+
+		assertSame(instance1, instance2);
 	}
 
 	@Test
@@ -166,6 +171,23 @@ public class SharedTableTest {
 	@Test
 	public void testHasDataEmptyTable() {
 		assertFalse(SharedTable.hasData());
+	}
+
+	@Test
+	public void testRepeatingHeaderAndLabelAddsARow() {
+		SharedTable.add("Image", "Value", 1.0);
+		SharedTable.add("Image", "Run", 1);
+		SharedTable.add("Image", "Value", 1.0);
+		SharedTable.add("Image", "Run", 2);
+
+		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
+		assertEquals(
+			"Adding data to the same column, to the row with the same label, should create a new row",
+			2, table.getRowCount());
+		assertEquals("Values in wrong order, older should be first", 1, table.get(
+			"Run").get(0), 1e-12);
+		assertEquals("Values in wrong order, older should be first", 2, table.get(
+			"Run").get(1), 1e-12);
 	}
 
 	@Test
@@ -210,26 +232,5 @@ public class SharedTableTest {
 		final Table<DefaultColumn<Double>, Double> table = SharedTable.getTable();
 		assertEquals(0, table.getColumnCount());
 		assertEquals(0, table.getRowCount());
-	}
-
-	@Test
-	public void testGetTableCopyPersists() {
-		final Table instance1 = SharedTable.getTable();
-		final Table instance2 = SharedTable.getTable();
-
-		assertSame(instance1, instance2);
-	}
-
-	@Test
-	public void testGetTableCopyDataCleared() {
-		final Table<DefaultColumn<Double>, Double> copy = SharedTable.getTable();
-		copy.appendRow();
-		copy.appendColumn();
-		copy.set(0, 0, 13.0);
-		final Table<DefaultColumn<Double>, Double> copy2 = SharedTable.getTable();
-
-		assertEquals(0, copy2.size());
-		assertEquals(0, copy2.getColumnCount());
-		assertEquals(0, copy2.getRowCount());
 	}
 }


### PR DESCRIPTION
* Fixes issue #123 
* Fixes a potential bug in `SharedTable` when comparing cell values
* Does code maintenance in `SharedTable` and its tests
* Updates unit and manual tests

This is a bit of a quick-fix, since in any case `imagej.table` is soon going to change to `scijava.table`. If the weirdness in clearing the copy in `SharedTable.getTable` still persists after those changes, they should be addressed at that time.

However I argue it's better to return a copy in this way than to expose the `Table` through the public API. Returning a reference to the instance would allow altering the contents of the `Table` against the way we want `SharedTable` to be used.

Maybe the best way to solve this problem would be to add a read-only interfaces for the tables in `scijava.table` a la `Vector3dc` and `Vector3d` in [JOML](https://github.com/JOML-CI/JOML).  