### PR TITLE
Replace deprecated option with imagej.deleteOtherVersions

### DIFF
--- a/IJinstall.sh
+++ b/IJinstall.sh
@@ -10,5 +10,5 @@ if [ "$1" = "" ]
   then
     echo "No ImageJ directory specified"
 else
-    mvn -Dimagej.app.directory="$1" -Ddelete.other.versions=true clean install
+    mvn -Dimagej.app.directory="$1" -Dimagej.deleteOtherVersions=true clean install
 fi

--- a/IJinstall_naughty.sh
+++ b/IJinstall_naughty.sh
@@ -11,5 +11,5 @@ if [ "$1" = "" ]
   then
     echo "No ImageJ directory specified"
 else
-    mvn -Dimagej.app.directory="$1" -Ddelete.other.versions=true -Dmaven.test.skip=true clean install
+    mvn -Dimagej.app.directory="$1" -Dimagej.deleteOtherVersions=true -Dmaven.test.skip=true clean install
 fi


### PR DESCRIPTION
Maven is complaining (warning) that `delete.other.versions` has been deprecated and should be replaced with `imagej.deleteOtherVersions`