### PR TITLE
Speed up isBinary() check

### DIFF
--- a/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/ElementUtil.java
@@ -96,16 +96,13 @@ public final class ElementUtil {
 
 	/**
 	 * Checks whether the interval contains only two distinct values.
-	 * <p>
-	 * NB a hacky brute force approach.
-	 * </p>
 	 *
 	 * @param interval an iterable interval.
 	 * @param <T> type of the elements in the interval.
 	 * @return true if only two distinct values, false if interval is empty
-	 *         or has more colors.
+	 *         or has more values.
 	 */
-	public static <T extends RealType<T> & NativeType<T>> boolean isColorsBinary(
+	public static <T extends RealType<T> & NativeType<T>> boolean isBinary(
 		final IterableInterval<T> interval)
 	{
 		if (interval.size() == 0) {
@@ -119,15 +116,32 @@ public final class ElementUtil {
 			return true;
 		}
 
-		final Set<Double> colors = new HashSet<>();
+		//a and b have the first pixel value
+		double a = interval.firstElement().getRealDouble();
+		double b = a;
+		double c;
+		
 		final Cursor<T> cursor = interval.cursor();
+		while (cursor.hasNext()){
+			cursor.fwd();
+			c = cursor.get().getRealDouble();
+			//if we encounter a different pixel value
+			// than a, assign it to b, and stop
+			if (c != a) {
+				b = c;
+				break;
+			}
+		}
+		//if we got to the end, there is only one pixel value,
+		//the next while is skipped, and we return true.
+		//Otherwise check the rest of the pixels
 		while (cursor.hasNext()) {
 			cursor.fwd();
-			final T e = cursor.get();
-			colors.add(e.getRealDouble());
-			if (colors.size() > 2) {
-				return false;
-			}
+		  c = cursor.get().getRealDouble();
+		  //if c is neither a or b the image is not binary
+		  if (c == a || c == b)
+		  	continue;
+		  return false;
 		}
 		return true;
 	}

--- a/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
@@ -166,7 +166,7 @@ public class ElementUtilTest {
 			.iterator();
 		interval.cursor().forEachRemaining(e -> e.setReal(intIterator.next()));
 
-		final boolean result = ElementUtil.isColorsBinary(interval);
+		final boolean result = ElementUtil.isBinary(interval);
 
 		assertTrue("An image with two colours should be binary color", result);
 	}
@@ -175,14 +175,14 @@ public class ElementUtilTest {
 	public void testIsColorsBinaryBooleanTypeAssignable() {
 		final Img<BitType> img = ArrayImgs.bits(1);
 
-		final boolean isBinary = ElementUtil.isColorsBinary(img);
+		final boolean isBinary = ElementUtil.isBinary(img);
 
 		assertTrue("A BitType image should be binary", isBinary);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testIsColorsBinaryThrowsNPEIfIntervalNull() {
-		final boolean result = ElementUtil.isColorsBinary(null);
+		final boolean result = ElementUtil.isBinary(null);
 
 		assertFalse("A null interval should not be binary color", result);
 	}
@@ -195,7 +195,7 @@ public class ElementUtilTest {
 			.iterator();
 		interval.cursor().forEachRemaining(e -> e.setReal(intIterator.next()));
 
-		final boolean result = ElementUtil.isColorsBinary(interval);
+		final boolean result = ElementUtil.isBinary(interval);
 
 		assertFalse(
 			"An image with more than two colours should not be binary color", result);
@@ -205,7 +205,7 @@ public class ElementUtilTest {
 	public void testIsColorsBinaryReturnsFalseIfIntervalEmpty() {
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(0);
 
-		final boolean result = ElementUtil.isColorsBinary(interval);
+		final boolean result = ElementUtil.isBinary(interval);
 
 		assertFalse("An empty image should not be binary color", result);
 	}
@@ -214,7 +214,7 @@ public class ElementUtilTest {
 	public void testIsColorsBinaryReturnsTrueForMonochrome() {
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(2, 2);
 
-		final boolean result = ElementUtil.isColorsBinary(interval);
+		final boolean result = ElementUtil.isBinary(interval);
 
 		assertTrue("Monochrome image should be binary color", result);
 	}

--- a/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/ElementUtilTest.java
@@ -159,8 +159,8 @@ public class ElementUtilTest {
 	}
 
 	@Test
-	public void testIsColorsBinary() {
-		// Create a test image with two colors
+	public void testIsBinary() {
+		// Create a test image with two values
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(2, 2);
 		final Iterator<Integer> intIterator = IntStream.iterate(0, i -> (i + 1) % 2)
 			.iterator();
@@ -168,11 +168,11 @@ public class ElementUtilTest {
 
 		final boolean result = ElementUtil.isBinary(interval);
 
-		assertTrue("An image with two colours should be binary color", result);
+		assertTrue("An image with two values should be binary", result);
 	}
 
 	@Test
-	public void testIsColorsBinaryBooleanTypeAssignable() {
+	public void testIsBinaryBooleanTypeAssignable() {
 		final Img<BitType> img = ArrayImgs.bits(1);
 
 		final boolean isBinary = ElementUtil.isBinary(img);
@@ -181,15 +181,15 @@ public class ElementUtilTest {
 	}
 
 	@Test(expected = NullPointerException.class)
-	public void testIsColorsBinaryThrowsNPEIfIntervalNull() {
+	public void testIsBinaryThrowsNPEIfIntervalNull() {
 		final boolean result = ElementUtil.isBinary(null);
 
-		assertFalse("A null interval should not be binary color", result);
+		assertFalse("A null interval should not be binary", result);
 	}
 
 	@Test
-	public void testIsColorsBinaryReturnsFalseForMulticolor() {
-		// Create a test image with many colors
+	public void testIsBinaryReturnsFalseForMultiValue() {
+		// Create a test image with many values
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(2, 2);
 		final Iterator<Integer> intIterator = IntStream.iterate(0, i -> i + 1)
 			.iterator();
@@ -198,25 +198,25 @@ public class ElementUtilTest {
 		final boolean result = ElementUtil.isBinary(interval);
 
 		assertFalse(
-			"An image with more than two colours should not be binary color", result);
+			"An image with more than two values should not be binary", result);
 	}
 
 	@Test
-	public void testIsColorsBinaryReturnsFalseIfIntervalEmpty() {
+	public void testIsBinaryReturnsFalseIfIntervalEmpty() {
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(0);
 
 		final boolean result = ElementUtil.isBinary(interval);
 
-		assertFalse("An empty image should not be binary color", result);
+		assertFalse("An empty image should not be binary", result);
 	}
 
 	@Test
-	public void testIsColorsBinaryReturnsTrueForMonochrome() {
+	public void testIsBinaryReturnsTrueForMonochrome() {
 		final IterableInterval<DoubleType> interval = ArrayImgs.doubles(2, 2);
 
 		final boolean result = ElementUtil.isBinary(interval);
 
-		assertTrue("Monochrome image should be binary color", result);
+		assertTrue("Monochrome image should be binary", result);
 	}
 
 	@AfterClass

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -368,7 +368,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			cancel(NOT_3D_IMAGE);
 			return;
 		}
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 			return;
 		}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -222,7 +222,7 @@ public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends 
 			return;
 		}
 
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 		}
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -182,7 +182,7 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>>
 			return;
 		}
 
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 		}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -325,7 +325,7 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>>
 			cancel(NO_IMAGE_OPEN);
 			return;
 		}
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 		}
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -373,7 +373,7 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends
 			cancel(NOT_3D_IMAGE);
 		}
 
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 		}
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -230,7 +230,7 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>>
             return;
 		}
 
-		if (!ElementUtil.isColorsBinary(inputImage)) {
+		if (!ElementUtil.isBinary(inputImage)) {
 			cancel(NOT_BINARY);
 		}
 	}


### PR DESCRIPTION
Remove high level things from inner loop like Object creation and
HashSet.add(), replacing them with low-level comparison logic.

If needed the same could be done using Object.equals() or similar, to
make isBinary() more generic.

Partially addresses #108 (see also https://github.com/imagej/imagej-ops/commit/dd5a3e3015e9f72e936447ba95c0cac84e822a4d#commitcomment-33284909)