### PR TITLE
Give users the choice of legacy/modern Connectivity

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -204,10 +204,10 @@ public class Connectivity implements PlugIn {
 					for (int z = ai.getAndIncrement(); z <= depth; z = ai.getAndIncrement()) {
 						for (int y = 0; y <= height; y++) {
 							for (int x = 0; x <= width; x++) {
-								 final byte[] octant = getOctant(stack, x, y, z);
-									if (octant[0] == 0)
-										continue;
-								 sumEulerInt[z] += getDeltaEuler(octant, eulerLUT);
+								final byte[] octant = getOctant(stack, x, y, z);
+								if (octant[0] == 0)
+									continue;
+								sumEulerInt[z] += getDeltaEuler(octant, eulerLUT);
 							}
 						}
 					}
@@ -403,12 +403,6 @@ public class Connectivity implements PlugIn {
 		final int xInc = Math.max(1, w1);
 		final int yInc = Math.max(1, h1);
 		final int zInc = Math.max(1, d1);
-
-		// vertex voxels contribute 3 edges
-		// this could be taken out into a variable to avoid recalculating it
-		// nStackEdges += getStackVertices(stack) * 3; = f * 3;
-
-		
 		
 		// left to right stack edges
 		for (int z = 0; z < depth; z += zInc) {
@@ -460,14 +454,6 @@ public class Connectivity implements PlugIn {
 		final int yInc = Math.max(1, h1);
 		final int zInc = Math.max(1, d1);
 		long nStackFaces = 0;
-
-		// vertex voxels contribute 3 faces
-		// this could be taken out into a variable to avoid recalculating it
-		// nStackFaces += getStackVertices(stack) * 3;
-
-		// edge voxels contribute 2 faces
-		// this could be taken out into a variable to avoid recalculating it
-		// nStackFaces += getStackEdges(stack) * 2;
 
 		// top and bottom faces
 		for (int z = 0; z < depth; z += zInc) {
@@ -668,10 +654,6 @@ public class Connectivity implements PlugIn {
 		final int zInc = Math.max(1, depth - 1);
 		long nEdgeVertices = 0;
 
-		// vertex voxels contribute 1 edge vertex each
-		// this could be taken out into a variable to avoid recalculating it
-		// nEdgeVertices += getStackVertices(stack);
-
 		// left->right edges
 		for (int z = 0; z < depth; z += zInc) {
 			for (int y = 0; y < height; y += yInc) {
@@ -736,10 +718,7 @@ public class Connectivity implements PlugIn {
 
 		final long f = getStackVertices(stack);
 		final long e = getStackEdges(stack) + 3 * f;
-		final long c = getStackFaces(stack) + 2 * e - 3 * f; // there are
-																// already 6 *
-		// f in 2 * e, so remove
-		// 3 * f
+		final long c = getStackFaces(stack) + 2 * e - 3 * f;
 		final long d = getEdgeVertices(stack) + f;
 		final long a = getFaceVertices(stack);
 		final long b = getFaceEdges(stack);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -247,14 +247,18 @@ public class Connectivity implements PlugIn {
 	 */
 	private byte[] getOctant(final ImageStack stack, final int x, final int y, final int z) {
 		final byte[] octant = new byte[9];
+		
+		final int x1 = x - 1;
+		final int y1 = y - 1;
+		final int z1 = z - 1;
 
-		octant[1] = getPixel(stack, x - 1, y - 1, z - 1);
-		octant[2] = getPixel(stack, x - 1, y, z - 1);
-		octant[3] = getPixel(stack, x, y - 1, z - 1);
-		octant[4] = getPixel(stack, x, y, z - 1);
-		octant[5] = getPixel(stack, x - 1, y - 1, z);
-		octant[6] = getPixel(stack, x - 1, y, z);
-		octant[7] = getPixel(stack, x, y - 1, z);
+		octant[1] = getPixel(stack, x1, y1, z1);
+		octant[2] = getPixel(stack, x1, y, z1);
+		octant[3] = getPixel(stack, x, y1, z1);
+		octant[4] = getPixel(stack, x, y, z1);
+		octant[5] = getPixel(stack, x1, y1, z);
+		octant[6] = getPixel(stack, x1, y, z);
+		octant[7] = getPixel(stack, x, y1, z);
 		octant[8] = getPixel(stack, x, y, z);
 		
 		for (int i = 1; i < 9; i++)
@@ -396,9 +400,9 @@ public class Connectivity implements PlugIn {
 		final int h1 = height - 1;
 		final int d1 = depth -1;
 		
-		final int xInc = Math.max(1, width - 1);
-		final int yInc = Math.max(1, height - 1);
-		final int zInc = Math.max(1, depth - 1);
+		final int xInc = Math.max(1, w1);
+		final int yInc = Math.max(1, h1);
+		final int zInc = Math.max(1, d1);
 
 		// vertex voxels contribute 3 edges
 		// this could be taken out into a variable to avoid recalculating it
@@ -452,9 +456,9 @@ public class Connectivity implements PlugIn {
 		final int h1 = height - 1;
 		final int d1 = depth -1;
 		
-		final int xInc = Math.max(1, width - 1);
-		final int yInc = Math.max(1, height - 1);
-		final int zInc = Math.max(1, depth - 1);
+		final int xInc = Math.max(1, w1);
+		final int yInc = Math.max(1, h1);
+		final int zInc = Math.max(1, d1);
 		long nStackFaces = 0;
 
 		// vertex voxels contribute 3 faces

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -94,6 +94,8 @@ import ij.plugin.PlugIn;
  */
 public class Connectivity implements PlugIn {
 
+	private final static int[] EULER_LUT = fillEulerLUT();
+	
 	/** working image width */
 	private int width = 0;
 
@@ -101,7 +103,7 @@ public class Connectivity implements PlugIn {
 	private int height = 0;
 
 	/** working image depth */
-	private int depth = 0;
+	private int depth = 0; 
 
 	@Override
 	public void run(final String arg) {
@@ -190,9 +192,6 @@ public class Connectivity implements PlugIn {
 		setDimensions(imp);
 		final ImageStack stack = imp.getImageStack();
 
-		final int eulerLUT[] = new int[256];
-		fillEulerLUT(eulerLUT);
-
 		final int[] sumEulerInt = new int[depth + 1];
 
 		final AtomicInteger ai = new AtomicInteger(0);
@@ -207,7 +206,7 @@ public class Connectivity implements PlugIn {
 								final byte[] octant = getOctant(stack, x, y, z);
 								if (octant[0] == 0)
 									continue;
-								sumEulerInt[z] += getDeltaEuler(octant, eulerLUT);
+								sumEulerInt[z] += getDeltaEuler(octant);
 							}
 						}
 					}
@@ -304,11 +303,9 @@ public class Connectivity implements PlugIn {
 	 * @param octant
 	 *            9 element array containing nVoxels in zeroth element and 8
 	 *            voxel values
-	 * @param LUT
-	 *            Euler LUT
 	 * @return or false if the point is Euler invariant or not
 	 */
-	private int getDeltaEuler(final byte[] octant, final int[] LUT) {
+	private int getDeltaEuler(final byte[] octant) {
 		if (octant[0] == 0)
 			return 0;
 		
@@ -357,7 +354,7 @@ public class Connectivity implements PlugIn {
 		}
 		else return 1;
 
-		return LUT[n];
+		return EULER_LUT[n];
 	}/* end getDeltaEuler */
 
 	/*------------------------------------------------------------------------*/
@@ -741,142 +738,142 @@ public class Connectivity implements PlugIn {
 	 *
 	 * This is derived from Toriwaki & Yonekura (2002) Table 2 for 26-connected
 	 * images.
-	 *
-	 * @param LUT
-	 *            Euler LUT
 	 */
-	private final void fillEulerLUT(final int[] LUT) {
-		LUT[1] = 1;
-		LUT[3] = 0;
-		LUT[5] = 0;
-		LUT[7] = -1;
-		LUT[9] = -2;
-		LUT[11] = -1;
-		LUT[13] = -1;
-		LUT[15] = 0;
-		LUT[17] = 0;
-		LUT[19] = -1;
-		LUT[21] = -1;
-		LUT[23] = -2;
-		LUT[25] = -3;
-		LUT[27] = -2;
-		LUT[29] = -2;
-		LUT[31] = -1;
-		LUT[33] = -2;
-		LUT[35] = -1;
-		LUT[37] = -3;
-		LUT[39] = -2;
-		LUT[41] = -1;
-		LUT[43] = -2;
-		LUT[45] = 0;
-		LUT[47] = -1;
-		LUT[49] = -1;
+	private final static int[] fillEulerLUT() {
+		final int[] lut = new int[256];
+		lut[1] = 1;
+		lut[3] = 0;
+		lut[5] = 0;
+		lut[7] = -1;
+		lut[9] = -2;
+		lut[11] = -1;
+		lut[13] = -1;
+		lut[15] = 0;
+		lut[17] = 0;
+		lut[19] = -1;
+		lut[21] = -1;
+		lut[23] = -2;
+		lut[25] = -3;
+		lut[27] = -2;
+		lut[29] = -2;
+		lut[31] = -1;
+		lut[33] = -2;
+		lut[35] = -1;
+		lut[37] = -3;
+		lut[39] = -2;
+		lut[41] = -1;
+		lut[43] = -2;
+		lut[45] = 0;
+		lut[47] = -1;
+		lut[49] = -1;
 
-		LUT[51] = 0;
-		LUT[53] = -2;
-		LUT[55] = -1;
-		LUT[57] = 0;
-		LUT[59] = -1;
-		LUT[61] = 1;
-		LUT[63] = 0;
-		LUT[65] = -2;
-		LUT[67] = -3;
-		LUT[69] = -1;
-		LUT[71] = -2;
-		LUT[73] = -1;
-		LUT[75] = 0;
-		LUT[77] = -2;
-		LUT[79] = -1;
-		LUT[81] = -1;
-		LUT[83] = -2;
-		LUT[85] = 0;
-		LUT[87] = -1;
-		LUT[89] = 0;
-		LUT[91] = 1;
-		LUT[93] = -1;
-		LUT[95] = 0;
-		LUT[97] = -1;
-		LUT[99] = 0;
+		lut[51] = 0;
+		lut[53] = -2;
+		lut[55] = -1;
+		lut[57] = 0;
+		lut[59] = -1;
+		lut[61] = 1;
+		lut[63] = 0;
+		lut[65] = -2;
+		lut[67] = -3;
+		lut[69] = -1;
+		lut[71] = -2;
+		lut[73] = -1;
+		lut[75] = 0;
+		lut[77] = -2;
+		lut[79] = -1;
+		lut[81] = -1;
+		lut[83] = -2;
+		lut[85] = 0;
+		lut[87] = -1;
+		lut[89] = 0;
+		lut[91] = 1;
+		lut[93] = -1;
+		lut[95] = 0;
+		lut[97] = -1;
+		lut[99] = 0;
 
-		LUT[101] = 0;
-		LUT[103] = 1;
-		LUT[105] = 4;
-		LUT[107] = 3;
-		LUT[109] = 3;
-		LUT[111] = 2;
-		LUT[113] = -2;
-		LUT[115] = -1;
-		LUT[117] = -1;
-		LUT[119] = 0;
-		LUT[121] = 3;
-		LUT[123] = 2;
-		LUT[125] = 2;
-		LUT[127] = 1;
-		LUT[129] = -6;
-		LUT[131] = -3;
-		LUT[133] = -3;
-		LUT[135] = 0;
-		LUT[137] = -3;
-		LUT[139] = -2;
-		LUT[141] = -2;
-		LUT[143] = -1;
-		LUT[145] = -3;
-		LUT[147] = 0;
-		LUT[149] = 0;
+		lut[101] = 0;
+		lut[103] = 1;
+		lut[105] = 4;
+		lut[107] = 3;
+		lut[109] = 3;
+		lut[111] = 2;
+		lut[113] = -2;
+		lut[115] = -1;
+		lut[117] = -1;
+		lut[119] = 0;
+		lut[121] = 3;
+		lut[123] = 2;
+		lut[125] = 2;
+		lut[127] = 1;
+		lut[129] = -6;
+		lut[131] = -3;
+		lut[133] = -3;
+		lut[135] = 0;
+		lut[137] = -3;
+		lut[139] = -2;
+		lut[141] = -2;
+		lut[143] = -1;
+		lut[145] = -3;
+		lut[147] = 0;
+		lut[149] = 0;
 
-		LUT[151] = 3;
-		LUT[153] = 0;
-		LUT[155] = 1;
-		LUT[157] = 1;
-		LUT[159] = 2;
-		LUT[161] = -3;
-		LUT[163] = -2;
-		LUT[165] = 0;
-		LUT[167] = 1;
-		LUT[169] = 0;
-		LUT[171] = -1;
-		LUT[173] = 1;
-		LUT[175] = 0;
-		LUT[177] = -2;
-		LUT[179] = -1;
-		LUT[181] = 1;
-		LUT[183] = 2;
-		LUT[185] = 1;
-		LUT[187] = 0;
-		LUT[189] = 2;
-		LUT[191] = 1;
-		LUT[193] = -3;
-		LUT[195] = 0;
-		LUT[197] = -2;
-		LUT[199] = 1;
+		lut[151] = 3;
+		lut[153] = 0;
+		lut[155] = 1;
+		lut[157] = 1;
+		lut[159] = 2;
+		lut[161] = -3;
+		lut[163] = -2;
+		lut[165] = 0;
+		lut[167] = 1;
+		lut[169] = 0;
+		lut[171] = -1;
+		lut[173] = 1;
+		lut[175] = 0;
+		lut[177] = -2;
+		lut[179] = -1;
+		lut[181] = 1;
+		lut[183] = 2;
+		lut[185] = 1;
+		lut[187] = 0;
+		lut[189] = 2;
+		lut[191] = 1;
+		lut[193] = -3;
+		lut[195] = 0;
+		lut[197] = -2;
+		lut[199] = 1;
 
-		LUT[201] = 0;
-		LUT[203] = 1;
-		LUT[205] = -1;
-		LUT[207] = 0;
-		LUT[209] = -2;
-		LUT[211] = 1;
-		LUT[213] = -1;
-		LUT[215] = 2;
-		LUT[217] = 1;
-		LUT[219] = 2;
-		LUT[221] = 0;
-		LUT[223] = 1;
-		LUT[225] = 0;
-		LUT[227] = 1;
-		LUT[229] = 1;
-		LUT[231] = 2;
-		LUT[233] = 3;
-		LUT[235] = 2;
-		LUT[237] = 2;
-		LUT[239] = 1;
-		LUT[241] = -1;
-		LUT[243] = 0;
-		LUT[245] = 0;
-		LUT[247] = 1;
-		LUT[249] = 2;
-		LUT[251] = 1;
-		LUT[253] = 1;
-		LUT[255] = 0;
+		lut[201] = 0;
+		lut[203] = 1;
+		lut[205] = -1;
+		lut[207] = 0;
+		lut[209] = -2;
+		lut[211] = 1;
+		lut[213] = -1;
+		lut[215] = 2;
+		lut[217] = 1;
+		lut[219] = 2;
+		lut[221] = 0;
+		lut[223] = 1;
+		lut[225] = 0;
+		lut[227] = 1;
+		lut[229] = 1;
+		lut[231] = 2;
+		lut[233] = 3;
+		lut[235] = 2;
+		lut[237] = 2;
+		lut[239] = 1;
+		lut[241] = -1;
+		lut[243] = 0;
+		lut[245] = 0;
+		lut[247] = 1;
+		lut[249] = 2;
+		lut[251] = 1;
+		lut[253] = 1;
+		lut[255] = 0;
+		
+		return lut;
 	}/* end fillEulerLUT */
 }

--- a/Legacy/bonej/src/main/resources/plugins.config
+++ b/Legacy/bonej/src/main/resources/plugins.config
@@ -33,6 +33,8 @@ Plugins>BoneJ>Analyze, "Calibrate SCANCO", org.bonej.plugins.DensityCalibrator("
 Plugins>BoneJ>Analyze, "Orientation", org.bonej.plugins.Orienteer
 Plugins>BoneJ>Analyze, "Particle Analyser", org.bonej.plugins.ParticleCounter
 
+Plugins>BoneJ>Connectivity, "Connectivity", org.bonej.plugins.Connectivity 
+ 
 Plugins>BoneJ, "Ellipsoid Factor", org.bonej.plugins.EllipsoidFactor
 Plugins>BoneJ, "Fit Sphere", org.bonej.plugins.SphereFitter
 Plugins>BoneJ, "Moments of Inertia", org.bonej.plugins.Moments

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -71,7 +71,7 @@ import org.scijava.ui.UIService;
  *
  * @author Richard Domander
  */
-@Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Connectivity")
+@Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Connectivity>Connectivity (Modern)")
 public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends ContextCommand {
 
 	static final String NEGATIVE_CONNECTIVITY =


### PR DESCRIPTION
Legacy Connectivity is about twice as fast but
does not have the advantage of ImgLib2's data
structures. Modern connectivity is half speed
but is more flexible in its accessibility from
client code and different data sources (network, disk,
memory, etc.)

Fixes #108

See also https://github.com/imagej/imagej-ops/pull/605