### PR TITLE
update scijava parent in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>24.0.0</version>
+        <version>26.0.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Travis build still fails after merging #177 - @imagejan on gitter thinks updating scijava parent to `26.0.0` should fix this - so let's try. I would be interested in what happens underneath if anyone can explain it? Why is Travis on Github happy with the changes, but Travis itself not? Thanks for all your help