### PR TITLE
Enhance Anisotropy to give consistent results

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/mil/MILPlane.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/mil/MILPlane.java
@@ -184,7 +184,7 @@ public class MILPlane<B extends BooleanType<B>> extends
 		long phaseChanges = 0;
 		for (long i = 0; i < samples; i++) {
 			final boolean current = getVoxel(access, start);
-			if (current && !previous) {
+			if (current != previous) {
 				phaseChanges++;
 			}
 			previous = current;

--- a/Modern/ops/src/test/java/org/bonej/ops/mil/MILPlaneTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/mil/MILPlaneTest.java
@@ -157,14 +157,15 @@ public class MILPlaneTest {
 	/**
 	 * Tests the op with an image with a foreground sheet on every other XY-slice.
 	 * Since the direction of the lines is (0, 0, 1) they should encounter all of
-	 * them. Their length should be image depth / sheets = 2.0.
+	 * them and count both in-out and out-in boundaries.
+	 * Their length should be image depth / (2 * sheets) = 1.0.
 	 */
 	@Test
 	public void testXYSheets() {
 		final Vector3dc milVector = (Vector3dc) IMAGE_J.op().run(MILPlane.class,
 			SHEETS, IDENTITY_ROTATION, 2L, 1.0, SEED);
 
-		assertEquals(2.0, milVector.length(), 1e-12);
+		assertEquals(1.0, milVector.length(), 1e-12);
 	}
 
 	/**

--- a/Modern/utilities/pom.xml
+++ b/Modern/utilities/pom.xml
@@ -120,6 +120,12 @@
             <groupId>net.imagej</groupId>
             <artifactId>ij</artifactId>
         </dependency>
+        
+        <!-- Fiji dependencies -->
+        <dependency>
+            <groupId>sc.fiji</groupId>
+            <artifactId>3D_Viewer</artifactId>
+        </dependency>
 
         <!-- SciJava dependencies -->
         <dependency>

--- a/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
@@ -1,0 +1,87 @@
+/*
+BSD 2-Clause License
+Copyright (c) 2019, Michael Doube
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.bonej.utilities;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.joml.Vector3d;
+import org.scijava.vecmath.Color3f;
+import org.scijava.vecmath.Point3f;
+
+import customnode.CustomPointMesh;
+import ij3d.Image3DUniverse;
+
+/**
+ * Convenience methods for displaying data.
+ * 
+ * Helpful for debugging and for users to visualise their results.
+ * 
+ * @author Michael Doube
+ *
+ */
+public class Visualiser {
+	/**
+	 * Plot a set of 3D coordinates in Benjamin Schmidt's ImageJ 3D Viewer
+	 *
+	 * @param points
+	 *            float[][] n x 3 array of 3D (x,y,z) coordinates
+	 * @param title
+	 *            String name of the dataset
+	 *
+	 */
+	public static void display3DPoints(final double[][] points, String title) {
+		final int nPoints = points.length;
+		// Create a CustomMesh from the coordinates
+		final List<Point3f> mesh = new ArrayList<>();
+		for (int i = 0; i < nPoints; i++) {
+			mesh.add(new Point3f((float) points[i][0], (float) points[i][1], (float) points[i][2]));
+		}
+
+		final CustomPointMesh cm = new CustomPointMesh(mesh);
+		final Color3f green = new Color3f(0.0f, 0.5f, 0.0f);
+		cm.setColor(green);
+		cm.setPointSize(1);
+
+		// Create a universe
+		final Image3DUniverse univ = new Image3DUniverse();
+		
+		// Add the points
+		univ.addCustomMesh(cm, title).setLocked(true);
+		
+		//show the universe
+		univ.show();
+	}
+	
+	public static void display3DPoints(List<Vector3d> vectors, String title) {
+		double[][] points = new double[vectors.size()][3];
+		int i = 0;
+		for (Vector3d v : vectors) {
+			points[i][0] = v.x;
+			points[i][1] = v.y;
+			points[i][2] = v.z;
+			i++;
+		}
+		display3DPoints(points, title);
+	}
+}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -67,6 +67,7 @@ import org.bonej.ops.mil.MILPlane;
 import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
+import org.bonej.utilities.Visualiser;
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
@@ -120,46 +121,59 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	// The default number of lines was found to be sensible after experimenting
 	// with data at hand. Other data may need a different number.
 	private static final int DEFAULT_LINES = 100;
-	private static final double DEFAULT_INCREMENT = 1.0;
+	private static final double DEFAULT_INCREMENT = 2.3;
 	private static BinaryFunctionOp<RandomAccessibleInterval<BitType>, Quaterniondc, Vector3d> milOp;
 	private static UnaryFunctionOp<Matrix4dc, Optional<Ellipsoid>> quadricToEllipsoidOp;
 	private static UnaryFunctionOp<List<Vector3d>, Matrix4dc> solveQuadricOp;
 	private final Function<Ellipsoid, Double> degreeOfAnisotropy =
 			ellipsoid -> 1.0 - (1.0/(ellipsoid.getC() * ellipsoid.getC())) / (1.0/(ellipsoid.getA() * ellipsoid.getA()));
 	@SuppressWarnings("unused")
+	
 	@Parameter(validater = "validateImage")
 	private ImgPlus<T> inputImage;
+	
 	@Parameter(label = "Directions",
 		description = "The number of times sampling is performed from different directions",
 		min = "9", style = NumberWidget.SPINNER_STYLE, required = false,
 		callback = "applyMinimum")
 	private Integer directions = DEFAULT_DIRECTIONS;
+	
 	@Parameter(label = "Lines per dimension",
 		description = "How many sampling lines are projected in both 2D directions (this number squared)",
 		min = "1", style = NumberWidget.SPINNER_STYLE, required = false,
 		callback = "applyMinimum")
 	private Integer lines = DEFAULT_LINES;
-	@Parameter(label = "Sampling increment", min = "0.01",
+	
+	@Parameter(label = "Sampling increment", min = "0.1",
 		description = "Distance between sampling points (in voxels)",
 		style = NumberWidget.SPINNER_STYLE, required = false, stepSize = "0.1",
 		callback = "applyMinimum")
 	private Double samplingIncrement = DEFAULT_INCREMENT;
+	
 	@Parameter(label = "Recommended minimums",
 		description = "Apply minimum recommended values to directions, lines, and increment",
 		persist = false, required = false, callback = "applyMinimum")
 	private boolean recommendedMin;
+	
 	@Parameter(visibility = ItemVisibility.MESSAGE)
 	private String instruction =
 		"NB parameter values can affect results significantly";
 	private boolean calibrationWarned;
+	
 	@Parameter(label = "Show radii",
 		description = "Show the radii of the fitted ellipsoid in the results",
 		required = false)
 	private boolean printRadii;
-	@Parameter(label = "Show eigenvectors",
-			description = "Show the eigenvectors of the fitted ellipsoid in the results",
+	
+	@Parameter(label = "Show Eigens",
+		description = "Show the eigenvectors and eigenvalues of the fitted ellipsoid in the results",
+		required = false)
+	private boolean printEigens;
+	
+	@Parameter(label = "Display MIL vectors",
+			description = "Show the vectors of the mean intercept lengths",
 			required = false)
-		private boolean printVectors;
+		private boolean displayMILVectors;
 	private static Long seed;
 
 	/**
@@ -237,7 +251,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			SharedTable.add(label, "Radius b", ellipsoid.getB());
 			SharedTable.add(label, "Radius c", ellipsoid.getC());
 		}
-		if (printVectors) {
+		if (printEigens) {
 			Matrix3d eigenVectors = new Matrix3d();
 			ellipsoid.getOrientation().get3x3(eigenVectors);
 			SharedTable.add(label, "m00", eigenVectors.m00);
@@ -249,6 +263,12 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			SharedTable.add(label, "m20", eigenVectors.m20);
 			SharedTable.add(label, "m21", eigenVectors.m21);
 			SharedTable.add(label, "m22", eigenVectors.m22);
+			final double d1 = 1/(ellipsoid.getC() * ellipsoid.getC());
+			final double d2 = 1/(ellipsoid.getB() * ellipsoid.getB());
+			final double d3 = 1/(ellipsoid.getA() * ellipsoid.getA());
+			SharedTable.add(label, "D1", d1);
+			SharedTable.add(label, "D2", d2);
+			SharedTable.add(label, "D3", d3);
 		}
 	}
 
@@ -305,6 +325,9 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			if (!ellipsoid.isPresent()) {
 				cancel("Anisotropy could not be calculated - ellipsoid fitting failed");
 				return null;
+			}
+			if (displayMILVectors) {
+				Visualiser.display3DPoints(pointCloud, "MIL points");
 			}
 			return ellipsoid.get();
 		}


### PR DESCRIPTION
Adresses #182 

This commit introduces a new utility for visualising data,
which users may find helpful to understand their anisotropy results.

The default sampling increment is set to 2.3 × pixel spacing,
which is about where the pixel spacing no longer creates an
'imprint' on the MIL of the structure's texture.
If sampling increment is too small (≲ 2px), the pixel grid size starts
to interfere with the feature size.

Count every foreground/background boundary
following the definition in Odgaard 1997, and the use in BoneJ1

Print the eigenvalues to the results table, after a user request