### PR TITLE
Don't attempt to draw points in the 3D viewer during testing

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -173,7 +173,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	@Parameter(label = "Display MIL vectors",
 			description = "Show the vectors of the mean intercept lengths",
 			required = false)
-		private boolean displayMILVectors;
+	private boolean displayMILVectors;
 	private static Long seed;
 
 	/**

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -116,7 +116,7 @@ public class AnisotropyWrapperTest {
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(AnisotropyWrapper.class,
-				true, "inputImage", imgPlus, "lines", 10, "directions", 10).get();
+				true, "inputImage", imgPlus, "lines", 10, "directions", 10, "displayMILVectors", false).get();
 
 		// VERIFY
 		assertFalse(module.isCanceled());


### PR DESCRIPTION
This test was implicitly selecting the option to show the MIL points in the 3D viewer, but then failing because it couldn't find a native library presumably to use to run the test.