### PR TITLE
Make pixel mask option not persist. Resets to true on each run.

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -90,7 +90,7 @@ public class ThicknessWrapper extends ContextCommand {
 
 	@Parameter(label = "Mask thickness maps",
 		description = "Remove pixel artifacts from the thickness maps",
-		required = false)
+		persist = false, required = false)
 	private boolean maskArtefacts = true;
 
 	@Parameter(label = "Trabecular thickness", type = ItemIO.OUTPUT)


### PR DESCRIPTION
Not masking leads to bias in the measurements, so it is unsafe to allow
masking to be disabled permanently.