### PR TITLE
Refactor Anisotropy

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/mil/ParallelLineGenerator.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/mil/ParallelLineGenerator.java
@@ -1,0 +1,25 @@
+package org.bonej.ops.mil;
+
+import org.joml.Vector3dc;
+
+/**
+ * An interface for random parallel line generators.
+ */
+public interface ParallelLineGenerator {
+    Line nextLine();
+
+    Vector3dc getDirection();
+
+    /**
+     * A line defined as a direction and point it passes through.
+     */
+    final class Line {
+        final Vector3dc point;
+        final Vector3dc direction;
+
+        public Line(Vector3dc point, Vector3dc direction) {
+            this.point = point;
+            this.direction = direction;
+        }
+    }
+}

--- a/Modern/ops/src/main/java/org/bonej/ops/mil/ParallelLineMIL.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/mil/ParallelLineMIL.java
@@ -23,34 +23,27 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.ops.mil;
 
-import java.util.Objects;
+import java.util.Arrays;
 import java.util.Random;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import net.imagej.ops.Contingent;
 import net.imagej.ops.Op;
-import net.imagej.ops.linalg.rotate.Rotate3d;
 import net.imagej.ops.special.function.AbstractBinaryFunctionOp;
-import net.imagej.ops.special.hybrid.BinaryHybridCFI1;
-import net.imagej.ops.special.hybrid.Hybrids;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.BooleanType;
-import net.imglib2.type.numeric.integer.LongType;
-import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.util.ValuePair;
 
 import org.joml.Intersectiond;
-import org.joml.Quaterniond;
-import org.joml.Quaterniondc;
 import org.joml.Vector2d;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+
+import static org.bonej.ops.mil.ParallelLineGenerator.Line;
 
 /**
  * An op that finds the mean intercept length (MIL) vector of an interval.
@@ -86,30 +79,22 @@ import org.scijava.plugin.Plugin;
  * @author Richard Domander
  */
 @Plugin(type = Op.class)
-public class MILPlane<B extends BooleanType<B>> extends
-	AbstractBinaryFunctionOp<RandomAccessibleInterval<B>, Quaterniondc, Vector3d>
+public class ParallelLineMIL<B extends BooleanType<B>> extends
+	AbstractBinaryFunctionOp<RandomAccessibleInterval<B>, ParallelLineGenerator, Vector3d>
 	implements Contingent
 {
-
-	private static BinaryHybridCFI1<Vector3d, Quaterniondc, Vector3d> rotateOp;
-	private final Random random = new Random();
 	/**
-	 * Number of sampling lines generated per dimension.
+	 * Length of the MIL vector sampled.
 	 * <p>
-	 * Each bin represents a sub-region of the plane where a sampling line
-	 * originates. For example, if bins = 2 then we get four lines originating
-	 * from the four quadrants of the plane.
+	 * The op generates and samples random lines through the interval until their total length
+	 * reaches the given value.
 	 * </p>
 	 * <p>
-	 * If left null, bins is set to <em>d</em>, where <em>d</em> is the largest
-	 * diagonal of the input interval.
-	 * </p>
-	 * <p>
-	 * The higher the number, the more likely you get an accurate result.
+	 * If left null, the length is 100.0 * d, where d = the size of the biggest dimension of the interval.
 	 * </p>
 	 */
 	@Parameter(required = false, persist = false)
-	private Long bins;
+	private Double milLength;
 	/**
 	 * The scalar step between positions on a sampling line where voxels are read.
 	 * <p>
@@ -138,34 +123,53 @@ public class MILPlane<B extends BooleanType<B>> extends
 	@Parameter(required = false, persist = false)
 	private Long seed;
 
+	private final Random random = new Random();
+
 	/**
 	 * Calculates the MIL vector of the interval.
 	 *
 	 * @param interval a 3D interval.
-	 * @param rotation direction of the MIL lines in the interval.
+	 * @param parallelLineGenerator a generator of random lines for MIL sampling.
 	 * @return a vector <b>v</b> parallel to the MIL lines, whose magnitude
 	 *         ||<b>v</b>|| = total length of lines / total phase changes from
 	 *         background to foreground
 	 */
 	@Override
 	public Vector3d calculate(final RandomAccessibleInterval<B> interval,
-		final Quaterniondc rotation)
+		final ParallelLineGenerator parallelLineGenerator)
 	{
-		matchOps();
-		final LinePlane samplingPlane = new LinePlane(interval, rotation, rotateOp);
 		if (seed != null) {
 			random.setSeed(seed);
-			samplingPlane.setSeed(seed);
 		}
 		if (increment == null) {
 			increment = 1.0;
 		}
-		if (bins == null) {
-			bins = defaultBins(interval);
+		if (milLength == null) {
+			final long maxDim = getMaxDim();
+			milLength = 100.0 * maxDim;
 		}
-		final Stream<Section> sections = findIntersectingSections(samplingPlane,
-			interval);
-		return sampleMILVector(interval, sections, samplingPlane.getDirection());
+		double totalLength = 0.0;
+		long totalIntercepts = 0L;
+		while (totalLength < milLength) {
+			final Line line = parallelLineGenerator.nextLine();
+			Section section = intersectInterval(line, interval);
+			if (section == null) {
+				continue;
+			}
+			final double length = Math.abs(section.tMax - section.tMin);
+			if (totalLength + length > milLength) {
+				section = limitSection(milLength, totalLength, section);
+			}
+			final ValuePair<Double, Long> mILValues = mILValues(interval, section, increment);
+			if (mILValues == null) {
+				continue;
+			}
+			totalLength += mILValues.getA();
+			totalIntercepts += mILValues.getB();
+		}
+		totalIntercepts = Math.max(totalIntercepts, 1);
+		final Vector3dc direction = parallelLineGenerator.getDirection();
+		return new Vector3d(direction).mul(totalLength / totalIntercepts);
 	}
 
 	@Override
@@ -193,20 +197,6 @@ public class MILPlane<B extends BooleanType<B>> extends
 		return phaseChanges;
 	}
 
-	private long defaultBins(final RandomAccessibleInterval<B> interval) {
-		final long sqSum = IntStream.range(0, 3).mapToLong(interval::dimension).map(
-			d -> d * d).sum();
-		return (long) Math.sqrt(sqSum);
-	}
-
-	private Stream<Section> findIntersectingSections(final LinePlane plane,
-		final Interval interval)
-	{
-		final Vector3dc direction = plane.getDirection();
-		return plane.getOrigins(bins).map(origin -> intersectInterval(origin,
-			direction, interval)).filter(Objects::nonNull);
-	}
-
 	private static <B extends BooleanType<B>> boolean getVoxel(
 		final RandomAccess<B> access, final Vector3d v)
 	{
@@ -216,28 +206,37 @@ public class MILPlane<B extends BooleanType<B>> extends
 		return access.get().get();
 	}
 
-	private static Section intersectInterval(final Vector3dc origin,
-		final Vector3dc direction, final Interval interval)
+	private static Section intersectInterval(final Line line, final Interval interval)
 	{
-		final Vector2d tValues = new Vector2d();
-		final Vector3dc o = new Vector3d(origin.x(), origin.y(), origin.z());
-		final Vector3dc d = new Vector3d(direction.x(), direction.y(), direction.z());
 		final Vector3dc min = new Vector3d(interval.min(0), interval.min(1),
 			interval.min(2));
 		final Vector3dc max = new Vector3d(interval.max(0) + 1, interval.max(1) + 1,
 			interval.max(2) + 1);
-		final boolean intersect = Intersectiond.intersectRayAab(o, d, min, max,
-			tValues);
+		final Vector2d tValues = new Vector2d();
+		final boolean intersect = Intersectiond.intersectRayAab(line.point, line.direction, min, max, tValues);
 		if (!intersect) {
 			return null;
 		}
-		return new Section(origin, direction, tValues.x, tValues.y);
+		return new Section(line, tValues.x, tValues.y);
+	}
+
+	private static Section limitSection(final double goalLength, final double totalLength,
+										final Section section)
+	{
+		final double remaining = goalLength - totalLength;
+		final double tMax;
+		if (section.tMax < section.tMin) {
+			tMax = section.tMin - remaining;
+		} else {
+			tMax = section.tMin + remaining;
+		}
+		return new Section(section.line, section.tMin, tMax);
 	}
 
 	private ValuePair<Double, Long> mILValues(final RandomAccessible<B> interval,
 		final Section section, final double increment)
 	{
-		final long intercepts = sampleSection(interval, section, section.direction,
+		final long intercepts = sampleSection(interval, section, section.line.direction,
 			increment);
 		if (intercepts < 0) {
 			return null;
@@ -246,25 +245,11 @@ public class MILPlane<B extends BooleanType<B>> extends
 		return new ValuePair<>(length, intercepts);
 	}
 
-	@SuppressWarnings("unchecked")
-	private void matchOps() {
-		rotateOp = Hybrids.binaryCFI1(ops(), Rotate3d.class, Vector3d.class,
-			new Vector3d(), new Quaterniond());
-	}
-
-	private Vector3d sampleMILVector(final RandomAccessible<B> interval,
-		final Stream<Section> sections, final Vector3dc direction)
-	{
-		final DoubleType totalLength = new DoubleType();
-		final LongType totalIntercepts = new LongType();
-		sections.map(s -> mILValues(interval, s, increment)).filter(
-			Objects::nonNull).forEach(p -> {
-				totalLength.set(p.a + totalLength.get());
-				totalIntercepts.set(p.b + totalIntercepts.get());
-			});
-		totalIntercepts.set(Math.max(totalIntercepts.get(), 1));
-		final Vector3d milVector = new Vector3d(direction);
-		return milVector.mul(totalLength.get() / totalIntercepts.get());
+	private long getMaxDim() {
+		final RandomAccessibleInterval<B> interval = in();
+		final long[] dimensions = new long[interval.numDimensions()];
+		interval.dimensions(dimensions);
+		return Arrays.stream(dimensions).max().orElse(0L);
 	}
 
 	private long sampleSection(final RandomAccessible<B> interval,
@@ -273,15 +258,15 @@ public class MILPlane<B extends BooleanType<B>> extends
 		// Add a random offset so that sampling doesn't always start from the same
 		// plane
 		final double startT = section.tMin + random.nextDouble() * increment;
-		final Vector3d samplePoint = new Vector3d(direction);
-		samplePoint.mul(startT);
-		samplePoint.add(section.origin);
-		final Vector3d gap = new Vector3d(direction);
-		gap.mul(increment);
 		final long samples = (long) Math.ceil((section.tMax - startT) / increment);
 		if (samples < 1) {
 			return -1;
 		}
+		final Vector3d samplePoint = new Vector3d(direction);
+		samplePoint.mul(startT);
+		samplePoint.add(section.line.point);
+		final Vector3d gap = new Vector3d(direction);
+		gap.mul(increment);
 		return countPhaseChanges(interval, samplePoint, gap, samples);
 	}
 	// endregion
@@ -293,22 +278,19 @@ public class MILPlane<B extends BooleanType<B>> extends
 	 * <em>t<sub>2</sub></em><b>v</b> where the origin + direction <b>v</b>
 	 * intersects the input interval.
 	 * <p>
-	 * The direction comes from the {@link LinePlane} used in the op.
+	 * The direction comes from the {@link PlaneParallelLineGenerator} used in the op.
 	 * </p>
 	 */
 	private static final class Section {
 
 		private final double tMin;
 		private final double tMax;
-		private final Vector3dc origin;
-		private final Vector3dc direction;
+		private final Line line;
 
-		private Section(final Vector3dc origin, final Vector3dc direction, final double tMin,
-						final double tMax) {
+		private Section(final Line line, final double tMin, final double tMax) {
+			this.line = line;
 			this.tMin = tMin;
 			this.tMax = tMax;
-			this.origin = origin;
-			this.direction = direction;
 		}
 	}
 

--- a/Modern/utilities/pom.xml
+++ b/Modern/utilities/pom.xml
@@ -136,6 +136,10 @@
             <groupId>org.scijava</groupId>
             <artifactId>scijava-table</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scijava</groupId>
+            <artifactId>vecmath</artifactId>
+        </dependency>
 
         <!-- ImgLib2 dependencies -->
         <dependency>

--- a/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.joml.Vector3d;
+import org.joml.Vector3dc;
 import org.scijava.vecmath.Color3f;
 import org.scijava.vecmath.Point3f;
 
@@ -73,13 +74,13 @@ public class Visualiser {
 		univ.show();
 	}
 	
-	public static void display3DPoints(List<Vector3d> vectors, String title) {
+	public static void display3DPoints(List<Vector3dc> vectors, String title) {
 		double[][] points = new double[vectors.size()][3];
 		int i = 0;
-		for (Vector3d v : vectors) {
-			points[i][0] = v.x;
-			points[i][1] = v.y;
-			points[i][2] = v.z;
+		for (Vector3dc v : vectors) {
+			points[i][0] = v.x();
+			points[i][1] = v.y();
+			points[i][2] = v.z();
 			i++;
 		}
 		display3DPoints(points, title);

--- a/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/Visualiser.java
@@ -22,16 +22,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.bonej.utilities;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
-import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.scijava.vecmath.Color3f;
 import org.scijava.vecmath.Point3f;
 
 import customnode.CustomPointMesh;
 import ij3d.Image3DUniverse;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Convenience methods for displaying data.
@@ -45,21 +46,13 @@ public class Visualiser {
 	/**
 	 * Plot a set of 3D coordinates in Benjamin Schmidt's ImageJ 3D Viewer
 	 *
-	 * @param points
-	 *            float[][] n x 3 array of 3D (x,y,z) coordinates
-	 * @param title
-	 *            String name of the dataset
-	 *
+	 * @param vectors a collection of 3D (x,y,z) vectors
+	 * @param title String name of the dataset
 	 */
-	public static void display3DPoints(final double[][] points, String title) {
-		final int nPoints = points.length;
+	public static void display3DPoints(final Collection<Vector3dc> vectors, final String title) {
 		// Create a CustomMesh from the coordinates
-		final List<Point3f> mesh = new ArrayList<>();
-		for (int i = 0; i < nPoints; i++) {
-			mesh.add(new Point3f((float) points[i][0], (float) points[i][1], (float) points[i][2]));
-		}
-
-		final CustomPointMesh cm = new CustomPointMesh(mesh);
+		final List<Point3f> points = vectors.stream().map(Visualiser::toPoint).collect(toList());
+		final CustomPointMesh cm = new CustomPointMesh(points);
 		final Color3f green = new Color3f(0.0f, 0.5f, 0.0f);
 		cm.setColor(green);
 		cm.setPointSize(1);
@@ -73,16 +66,8 @@ public class Visualiser {
 		//show the universe
 		univ.show();
 	}
-	
-	public static void display3DPoints(List<Vector3dc> vectors, String title) {
-		double[][] points = new double[vectors.size()][3];
-		int i = 0;
-		for (Vector3dc v : vectors) {
-			points[i][0] = v.x();
-			points[i][1] = v.y();
-			points[i][2] = v.z();
-			i++;
-		}
-		display3DPoints(points, title);
+
+	private static Point3f toPoint(final Vector3dc v) {
+		return new Point3f((float) v.x(), (float) v.y(), (float) v.z());
 	}
 }

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -34,6 +34,7 @@ import static org.scijava.ui.DialogPrompt.OptionType.OK_CANCEL_OPTION;
 import static org.scijava.ui.DialogPrompt.Result.OK_OPTION;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -49,9 +50,12 @@ import java.util.function.Function;
 
 import net.imagej.ImgPlus;
 import net.imagej.ops.OpService;
+import net.imagej.ops.linalg.rotate.Rotate3d;
 import net.imagej.ops.special.function.BinaryFunctionOp;
 import net.imagej.ops.special.function.Functions;
 import net.imagej.ops.special.function.UnaryFunctionOp;
+import net.imagej.ops.special.hybrid.BinaryHybridCFI1;
+import net.imagej.ops.special.hybrid.Hybrids;
 import net.imagej.ops.stats.regression.leastSquares.Quadric;
 import net.imagej.units.UnitService;
 import net.imglib2.RandomAccessibleInterval;
@@ -63,7 +67,9 @@ import org.apache.commons.math3.random.RandomVectorGenerator;
 import org.apache.commons.math3.random.UnitSphereRandomVectorGenerator;
 import org.bonej.ops.ellipsoid.Ellipsoid;
 import org.bonej.ops.ellipsoid.QuadricToEllipsoid;
-import org.bonej.ops.mil.MILPlane;
+import org.bonej.ops.mil.ParallelLineGenerator;
+import org.bonej.ops.mil.ParallelLineMIL;
+import org.bonej.ops.mil.PlaneParallelLineGenerator;
 import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
@@ -122,7 +128,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	// with data at hand. Other data may need a different number.
 	private static final int DEFAULT_LINES = 100;
 	private static final double DEFAULT_INCREMENT = 2.3;
-	private static BinaryFunctionOp<RandomAccessibleInterval<BitType>, Quaterniondc, Vector3d> milOp;
+	private static BinaryFunctionOp<RandomAccessibleInterval<BitType>, ParallelLineGenerator, Vector3d> milOp;
 	private static UnaryFunctionOp<Matrix4dc, Optional<Ellipsoid>> quadricToEllipsoidOp;
 	private static UnaryFunctionOp<List<Vector3d>, Matrix4dc> solveQuadricOp;
 	private final Function<Ellipsoid, Double> degreeOfAnisotropy =
@@ -201,6 +207,8 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	@Parameter
 	private CommandService commandService;
 	private static UsageReporter reporter;
+	private static BinaryHybridCFI1<Vector3d, Quaterniondc, Vector3d> rotateOp;
+	private double milLength;
 
 	@Override
 	public void run() {
@@ -209,12 +217,13 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			inputImage);
 		final List<Subspace<BitType>> subspaces = HyperstackUtils.split3DSubspaces(
 			bitImgPlus).collect(toList());
-		matchOps(subspaces.get(0));
+		calculateMILLength(subspaces.get(0).interval);
+		matchOps(subspaces.get(0).interval);
 		final List<Ellipsoid> ellipsoids = new ArrayList<>();
 		for (int i = 0; i < subspaces.size(); i++) {
 			statusService.showStatus("Anisotropy: sampling subspace #" + (i + 1));
-			final Subspace<BitType> subspace = subspaces.get(i);
-			final Ellipsoid ellipsoid = milEllipsoid(subspace);
+			final RandomAccessibleInterval<BitType> interval = subspaces.get(i).interval;
+			final Ellipsoid ellipsoid = milEllipsoid(interval);
 			if (ellipsoid == null) {
 				return;
 			}
@@ -236,6 +245,14 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 			throw new NullPointerException("Reporter cannot be null");
 		}
 		AnisotropyWrapper.reporter = reporter;
+	}
+
+
+	private void calculateMILLength(final RandomAccessibleInterval<BitType> interval) {
+		final long[] dimensions = new long[interval.numDimensions()];
+		interval.dimensions(dimensions);
+		final long maxDim = Arrays.stream(dimensions).max().orElse(0L);
+		milLength = lines * lines * maxDim;
 	}
 
 	private void addResult(final Subspace<BitType> subspace,
@@ -301,9 +318,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	}
 
 	@SuppressWarnings("unchecked")
-	private void matchOps(final Subspace<BitType> subspace) {
-		milOp = Functions.binary(opService, MILPlane.class, Vector3d.class,
-			subspace.interval, new Quaterniond(), lines, samplingIncrement);
+	private void matchOps(final RandomAccessibleInterval<BitType> interval) {
 		final List<Vector3d> tmpPoints = generate(Vector3d::new).limit(
 			Quadric.MIN_DATA).collect(toList());
 		solveQuadricOp = Functions.unary(opService, Quadric.class, Matrix4dc.class,
@@ -311,12 +326,18 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 		final Matrix4dc matchingMock = new Matrix4d();
 		quadricToEllipsoidOp = (UnaryFunctionOp) Functions.unary(opService,
 			QuadricToEllipsoid.class, Optional.class, matchingMock);
+		rotateOp = Hybrids.binaryCFI1(opService, Rotate3d.class, Vector3d.class,
+				new Vector3d(), new Quaterniond());
+		ParallelLineGenerator generator =
+				new PlaneParallelLineGenerator(interval, new Quaterniond(), rotateOp, lines);
+		milOp = Functions.binary(opService, ParallelLineMIL.class, Vector3d.class,
+				interval, generator, milLength, samplingIncrement);
 	}
 
-	private Ellipsoid milEllipsoid(final Subspace<BitType> subspace) {
+	private Ellipsoid milEllipsoid(final RandomAccessibleInterval<BitType> interval) {
 		final List<Vector3d> pointCloud;
 		try {
-			pointCloud = runDirectionsInParallel(subspace.interval);
+			pointCloud = runDirectionsInParallel(interval);
 			if (pointCloud.size() < Quadric.MIN_DATA) {
 				cancel("Anisotropy could not be calculated - too few points");
 				return null;
@@ -338,15 +359,13 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 		return null;
 	}
 
-	/**
-	 * Creates a random isotropically distributed quaternion.
-	 *
-	 * @return a (rotation) quaternion which can be used as a parameter for the
-	 *         op.
-	 */
-	private static synchronized Quaterniondc randomQuaternion() {
+	private Callable<Vector3d> createMILTask(final RandomAccessibleInterval<BitType> interval) {
+		// A random isotropically distributed quaternion
 		final double[] v = qGenerator.nextVector();
-		return new Quaterniond(v[0], v[1], v[2], v[3]);
+		final Quaterniond quaternion = new Quaterniond(v[0], v[1], v[2], v[3]);
+		final PlaneParallelLineGenerator generator =
+				new PlaneParallelLineGenerator(interval, quaternion, rotateOp, lines);
+		return () -> milOp.calculate(interval, generator);
 	}
 
 	private List<Vector3d> runDirectionsInParallel(
@@ -361,9 +380,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 		// but we need some kind of upper bound
 		final int nThreads = Math.max(5, cores);
 		final ExecutorService executor = Executors.newFixedThreadPool(nThreads);
-		final Callable<Vector3d> milTask = () -> milOp.calculate(interval,
-			randomQuaternion());
-		final List<Future<Vector3d>> futures = generate(() -> milTask).limit(
+		final List<Future<Vector3d>> futures = generate(() -> createMILTask(interval)).limit(
 			directions).map(executor::submit).collect(toList());
 		final List<Vector3d> pointCloud = Collections.synchronizedList(
 			new ArrayList<>(directions));
@@ -435,7 +452,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends
 	 * <p>
 	 * The method's here only to enable reproducible unit test.
 	 * </p>
-	 * 
+	 *
 	 * @param seed a seed number.
 	 * @see Random#setSeed
 	 */

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -77,6 +77,13 @@ public class AnisotropyWrapperTest {
 	private static final ImageJ IMAGE_J = new ImageJ();
 	private static ImgPlus<BitType> hyperSheets;
 
+	@Before
+	public void setup() {
+		UsageReporter mockReporter = mock(UsageReporter.class);
+		doNothing().when(mockReporter).reportEvent(anyString());
+		AnisotropyWrapper.setReporter(mockReporter);
+	}
+
 	@After
 	public void tearDown() {
 		Mockito.reset(IMAGE_J.ui().getDefaultUI());

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>26.0.0</version>
+        <version>28.0.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
@mdoube I had an idea how to improve Anisotropy, and wanted to open this PR for discussion, before it's ready.

The current version blindly shoots sampling vectors from a plane through through the image. This plane needs to be bigger than the stack, so that the vectors have the chance to cover the entire stack, regardless of the plane's orientation. It needs to be _d x d_ to be exact, where _d_ is the largest diagonal of the stack. This means that some of the random vectors are going to miss the stack entirely. The result is that the total length of the MIL vector sampled through the stack will change between runs. I think this is why you see variance in the anisotropy of an empty stack, and why it's not _0.0_.

Here I simply keep generating new random vectors, until a predetermined MIL vector total length is reached. Thus MIL vectors have the same base length (before dividing by interceptions). Attached [here](https://github.com/bonej-org/BoneJ2/files/4172066/ani-comp.txt)
 are some initial results. I think with the new method the anisotropy of an empty stack is close enough to _0.0_ to be attributed to the usual floating point rounding malarkey. 
