### PR TITLE
Add minimum increment to Anisotropy based on pixel size

### DIFF
--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
@@ -1,0 +1,74 @@
+/*
+BSD 2-Clause License
+Copyright (c) 2020, Michael Doube, Richard Domander, Alessandro Felder
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package org.bonej.wrapperPlugins;
+
+import net.imagej.ImageJ;
+import org.bonej.utilities.SharedTable;
+import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockito.Mockito;
+import org.scijava.ui.UserInterface;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+/**
+ * An abstract base test class that handles basic setup and tear down for testing wrapper plugins.
+ * <p>
+ * NB Remember to call the methods in this class if you override/hide the methods!
+ * </p>
+ * @author Richard Domander
+ */
+public abstract class AbstractWrapperTest {
+    protected static ImageJ imageJ;
+    protected static final UsageReporter MOCK_REPORTER = mock(UsageReporter.class);
+    protected static final UserInterface MOCK_UI = mock(UserInterface.class);
+
+    @BeforeClass
+    public static void basicOneTimeSetup() {
+        imageJ = new ImageJ();
+    }
+
+    @Before
+    public void setup() {
+        imageJ.ui().setDefaultUI(MOCK_UI);
+        doNothing().when(MOCK_REPORTER).reportEvent(anyString());
+    }
+
+    @After
+    public void tearDown() {
+        Mockito.reset(MOCK_UI);
+        Mockito.reset(MOCK_REPORTER);
+        SharedTable.reset();
+    }
+
+    @AfterClass
+    public static void basicOneTimeTearDown() {
+        imageJ.context().dispose();
+    }
+}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
@@ -31,6 +31,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
+import org.scijava.command.CommandService;
 import org.scijava.ui.UserInterface;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -45,13 +46,23 @@ import static org.mockito.Mockito.mock;
  * @author Richard Domander
  */
 public abstract class AbstractWrapperTest {
-    protected static ImageJ imageJ;
+    private static ImageJ imageJ;
     protected static final UsageReporter MOCK_REPORTER = mock(UsageReporter.class);
     protected static final UserInterface MOCK_UI = mock(UserInterface.class);
+    private static CommandService commandService;
+
+    protected static CommandService command() {
+        return commandService;
+    }
+
+    protected static ImageJ imageJ() {
+        return imageJ;
+    }
 
     @BeforeClass
     public static void basicOneTimeSetup() {
         imageJ = new ImageJ();
+        commandService = imageJ.command();
     }
 
     @Before

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -367,7 +367,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 			assertEquals("Column has wrong number of rows", 2, column.size());
 			for (int j = 0; j < 2; j++) {
 				assertEquals("Column has an incorrect value", expectedValues[i][j],
-					column.get(j).doubleValue(), 1e-12);
+						column.get(j), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -80,7 +80,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 			"0", length, length, "255.0", "255.0" };
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", line,
 			"pruneCycleMethod", "None", "verbose", true, "pruneEnds", false).get();
 
@@ -110,7 +110,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None", "verbose", false).get();
 
@@ -128,7 +128,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 			exceptionFile);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -146,7 +146,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -166,7 +166,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -184,7 +184,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -204,7 +204,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -227,7 +227,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None").get();
 
@@ -244,7 +244,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus,
 			"pruneCycleMethod", "None").get();
 
@@ -258,7 +258,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ(),
 			AnalyseSkeletonWrapper.class);
 	}
 
@@ -271,7 +271,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -283,7 +283,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			AnalyseSkeletonWrapper.class);
 	}
 
@@ -295,7 +295,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		CommandModule module = imageJ.command().run(AnalyseSkeletonWrapper.class,
+		CommandModule module = command().run(AnalyseSkeletonWrapper.class,
 			true, "inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons",
 			false, "calculateShortestPaths", true).get();
 
@@ -304,7 +304,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		assertNull(module.getOutput("shortestPaths"));
 
 		// EXECUTE
-		module = imageJ.command().run(AnalyseSkeletonWrapper.class, true,
+		module = command().run(AnalyseSkeletonWrapper.class, true,
 			"inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons", true,
 			"calculateShortestPaths", false).get();
 
@@ -313,7 +313,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		assertNull(module.getOutput("shortestPaths"));
 
 		// EXECUTE
-		module = imageJ.command().run(AnalyseSkeletonWrapper.class, true,
+		module = command().run(AnalyseSkeletonWrapper.class, true,
 			"inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons", true,
 			"calculateShortestPaths", true).get();
 
@@ -349,7 +349,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 					3.0 }, { 1.0, 3.0 }, { 0.0, 0.0 } };
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixels,
 			"pruneCycleMethod", "None", "calculateShortestPaths", true).get();
 
@@ -384,7 +384,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None", "calculateShortestPaths", false).get();
 
@@ -409,7 +409,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		square.getStack().getProcessor(1).set(2, 2, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", square,
 			"pruneCycleMethod", "None").get();
 
@@ -428,7 +428,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -450,7 +450,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 			FILL_BLACK);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", blank).get();
 
 		// VERIFY
@@ -474,7 +474,7 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		image.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", image).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -76,6 +76,7 @@ public class AnalyseSkeletonWrapperTest {
 
 	private static final ImageJ IMAGE_J = new ImageJ();
 	private static final UsageReporter mockReporter = mock(UsageReporter.class);
+	private UserInterface mockUI = mock(UserInterface.class);
 
 	@Test
 	public void testAdditionalResultsTable() throws Exception {
@@ -135,12 +136,10 @@ public class AnalyseSkeletonWrapperTest {
 	public void testBadFormatIntensityImageCancelsPlugin() throws Exception {
 		// SETUP
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
-		final UserInterface mockUI = mock(UserInterface.class);
 		final File exceptionFile = mock(File.class);
 		when(exceptionFile.getAbsolutePath()).thenReturn("file.foo");
 		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
 			exceptionFile);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(
@@ -158,7 +157,6 @@ public class AnalyseSkeletonWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_CHANNEL_DIMENSIONS +
 			". Please split the channels.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
@@ -238,8 +236,6 @@ public class AnalyseSkeletonWrapperTest {
 	@Test
 	public void testNoImageWhenNoSkeletonisation() throws Exception {
 		// SETUP
-		final UserInterface mockUI = mock(UserInterface.class);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus pixel = NewImage.createByteImage("Test", 3, 3, 1,
 			FILL_BLACK);
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -260,7 +256,6 @@ public class AnalyseSkeletonWrapperTest {
 	public void testNoSkeletonsCancelsPlugin() throws Exception {
 		// SETUP
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(
@@ -276,7 +271,7 @@ public class AnalyseSkeletonWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsPlugin() throws Exception {
+	public void testNonBinaryImageCancelsPlugin() {
 		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
 			AnalyseSkeletonWrapper.class);
 	}
@@ -301,7 +296,7 @@ public class AnalyseSkeletonWrapperTest {
 	}
 
 	@Test
-	public void testNullImageCancelsPlugin() throws Exception {
+	public void testNullImageCancelsPlugin() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			AnalyseSkeletonWrapper.class);
 	}
@@ -420,8 +415,6 @@ public class AnalyseSkeletonWrapperTest {
 	 */
 	@Test
 	public void testSkeletonImageWhenSkeletonised() throws Exception {
-		final UserInterface mockUI = mock(UserInterface.class);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus square = NewImage.createByteImage("Test", 4, 4, 1,
 			FILL_BLACK);
 		square.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -446,7 +439,6 @@ public class AnalyseSkeletonWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_TIME_DIMENSIONS +
 			". Please split the hyperstack.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
@@ -506,18 +498,25 @@ public class AnalyseSkeletonWrapperTest {
 
 	@Before
 	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+
 		doNothing().when(mockReporter).reportEvent(anyString());
 	}
 
 
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		Mockito.reset(mockReporter);
+
 		SharedTable.reset();
 	}
 
 	@BeforeClass
-	public static void oneTimeSetup() { AnalyseSkeletonWrapper.setReporter(mockReporter); }
+	public static void oneTimeSetup() {
+		AnalyseSkeletonWrapper.setReporter(mockReporter);
+	}
 
 	@AfterClass
 	public static void oneTimeTearDown() {
@@ -526,10 +525,8 @@ public class AnalyseSkeletonWrapperTest {
 
 	private void mockIntensityFileOpening(final String path) {
 		final File intensityFile = mock(File.class);
-		final UserInterface mockUI = mock(UserInterface.class);
 		when(intensityFile.getAbsolutePath()).thenReturn(path);
 		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
 			intensityFile);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.after;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -49,22 +48,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import net.imagej.ImageJ;
-
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.PrimitiveColumn;
-import org.scijava.ui.UserInterface;
 
 /**
  * Tests for {@link AnalyseSkeletonWrapper}
@@ -72,11 +62,7 @@ import org.scijava.ui.UserInterface;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class AnalyseSkeletonWrapperTest {
-
-	private static final ImageJ IMAGE_J = new ImageJ();
-	private static final UsageReporter mockReporter = mock(UsageReporter.class);
-	private UserInterface mockUI = mock(UserInterface.class);
+public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testAdditionalResultsTable() throws Exception {
@@ -94,7 +80,7 @@ public class AnalyseSkeletonWrapperTest {
 			"0", length, length, "255.0", "255.0" };
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", line,
 			"pruneCycleMethod", "None", "verbose", true, "pruneEnds", false).get();
 
@@ -124,7 +110,7 @@ public class AnalyseSkeletonWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None", "verbose", false).get();
 
@@ -138,11 +124,11 @@ public class AnalyseSkeletonWrapperTest {
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
 		final File exceptionFile = mock(File.class);
 		when(exceptionFile.getAbsolutePath()).thenReturn("file.foo");
-		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
+		when(MOCK_UI.chooseFile(any(File.class), anyString())).thenReturn(
 			exceptionFile);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -160,7 +146,7 @@ public class AnalyseSkeletonWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -168,7 +154,7 @@ public class AnalyseSkeletonWrapperTest {
 			.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
 
@@ -180,7 +166,7 @@ public class AnalyseSkeletonWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -198,7 +184,7 @@ public class AnalyseSkeletonWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -218,7 +204,7 @@ public class AnalyseSkeletonWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -241,7 +227,7 @@ public class AnalyseSkeletonWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None").get();
 
@@ -249,7 +235,7 @@ public class AnalyseSkeletonWrapperTest {
 		assertFalse(
 			"Sanity check failed: plugin cancelled before image could have been shown",
 			module.isCanceled());
-		verify(mockUI, after(250).never()).show(any(ImagePlus.class));
+		verify(MOCK_UI, after(250).never()).show(any(ImagePlus.class));
 	}
 
 	@Test
@@ -258,7 +244,7 @@ public class AnalyseSkeletonWrapperTest {
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus,
 			"pruneCycleMethod", "None").get();
 
@@ -266,13 +252,13 @@ public class AnalyseSkeletonWrapperTest {
 		assertTrue("Plugin should have cancelled", module.isCanceled());
 		assertEquals("Cancel reason is incorrect", NO_SKELETONS, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
 			AnalyseSkeletonWrapper.class);
 	}
 
@@ -285,7 +271,7 @@ public class AnalyseSkeletonWrapperTest {
 		mockIntensityFileOpening(intensityPath);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", inputImage,
 			"pruneCycleMethod", "Lowest intensity voxel").get();
 
@@ -297,7 +283,7 @@ public class AnalyseSkeletonWrapperTest {
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			AnalyseSkeletonWrapper.class);
 	}
 
@@ -309,7 +295,7 @@ public class AnalyseSkeletonWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		CommandModule module = IMAGE_J.command().run(AnalyseSkeletonWrapper.class,
+		CommandModule module = imageJ.command().run(AnalyseSkeletonWrapper.class,
 			true, "inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons",
 			false, "calculateShortestPaths", true).get();
 
@@ -318,7 +304,7 @@ public class AnalyseSkeletonWrapperTest {
 		assertNull(module.getOutput("shortestPaths"));
 
 		// EXECUTE
-		module = IMAGE_J.command().run(AnalyseSkeletonWrapper.class, true,
+		module = imageJ.command().run(AnalyseSkeletonWrapper.class, true,
 			"inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons", true,
 			"calculateShortestPaths", false).get();
 
@@ -327,7 +313,7 @@ public class AnalyseSkeletonWrapperTest {
 		assertNull(module.getOutput("shortestPaths"));
 
 		// EXECUTE
-		module = IMAGE_J.command().run(AnalyseSkeletonWrapper.class, true,
+		module = imageJ.command().run(AnalyseSkeletonWrapper.class, true,
 			"inputImage", pixel, "pruneCycleMethod", "None", "displaySkeletons", true,
 			"calculateShortestPaths", true).get();
 
@@ -363,7 +349,7 @@ public class AnalyseSkeletonWrapperTest {
 					3.0 }, { 1.0, 3.0 }, { 0.0, 0.0 } };
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixels,
 			"pruneCycleMethod", "None", "calculateShortestPaths", true).get();
 
@@ -398,7 +384,7 @@ public class AnalyseSkeletonWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", pixel,
 			"pruneCycleMethod", "None", "calculateShortestPaths", false).get();
 
@@ -423,7 +409,7 @@ public class AnalyseSkeletonWrapperTest {
 		square.getStack().getProcessor(1).set(2, 2, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", square,
 			"pruneCycleMethod", "None").get();
 
@@ -431,7 +417,7 @@ public class AnalyseSkeletonWrapperTest {
 		assertFalse(
 			"Sanity check failed: plugin cancelled before image could have been shown",
 			module.isCanceled());
-		verify(mockUI, timeout(1000)).show(any(ImagePlus.class));
+		verify(MOCK_UI, timeout(1000)).show(any(ImagePlus.class));
 	}
 
 	@Test
@@ -442,7 +428,7 @@ public class AnalyseSkeletonWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -450,7 +436,7 @@ public class AnalyseSkeletonWrapperTest {
 			module.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
 
@@ -464,13 +450,13 @@ public class AnalyseSkeletonWrapperTest {
 			FILL_BLACK);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", blank).get();
 
 		// VERIFY
 		assertTrue("Sanity check failed: method didn't cancel", module
 			.isCanceled());
-		verify(mockReporter, timeout(1000).times(0)).reportEvent(anyString());
+		verify(MOCK_REPORTER, timeout(1000).times(0)).reportEvent(anyString());
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -488,45 +474,23 @@ public class AnalyseSkeletonWrapperTest {
 		image.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			AnalyseSkeletonWrapper.class, true, "inputImage", image).get();
 
 		// VERIFY
 		assertFalse("Sanity check failed: method cancelled", module.isCanceled());
-		verify(mockReporter, timeout(1000)).reportEvent(anyString());
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-
-		doNothing().when(mockReporter).reportEvent(anyString());
-	}
-
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		Mockito.reset(mockReporter);
-
-		SharedTable.reset();
+		verify(MOCK_REPORTER, timeout(1000)).reportEvent(anyString());
 	}
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		AnalyseSkeletonWrapper.setReporter(mockReporter);
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
+		AnalyseSkeletonWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	private void mockIntensityFileOpening(final String path) {
 		final File intensityFile = mock(File.class);
 		when(intensityFile.getAbsolutePath()).thenReturn(path);
-		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
+		when(MOCK_UI.chooseFile(any(File.class), anyString())).thenReturn(
 			intensityFile);
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -76,7 +76,7 @@ public class AnisotropyWrapperTest {
 
 	private static final ImageJ IMAGE_J = new ImageJ();
 	private static ImgPlus<BitType> hyperSheets;
-	private static final UserInterface mockUI = mock(UserInterface.class);
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@Before
 	public void setup() {
@@ -90,7 +90,7 @@ public class AnisotropyWrapperTest {
 	}
 
 	@Test
-	public void test2DImageCancelsWrapper() throws Exception {
+	public void test2DImageCancelsWrapper() {
 		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
 			AnisotropyWrapper.class);
 	}
@@ -138,7 +138,6 @@ public class AnisotropyWrapperTest {
 		final String expectedStart = "The voxels in the image are anisotropic";
 		when(mockUI.dialogPrompt(startsWith(expectedStart), anyString(), eq(
 			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(AnisotropyWrapper.class,
@@ -171,13 +170,13 @@ public class AnisotropyWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsWrapper() throws Exception {
+	public void testNonBinaryImageCancelsWrapper() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			AnisotropyWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsWrapper() throws Exception {
+	public void testNullImageCancelsWrapper() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			AnisotropyWrapper.class);
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -68,7 +68,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsWrapper() {
-		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ(),
 			AnisotropyWrapper.class);
 	}
 
@@ -90,7 +90,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 				WARNING_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(AnisotropyWrapper.class,
+		final CommandModule module = command().run(AnisotropyWrapper.class,
 				true, "inputImage", imgPlus, "lines", 10, "directions", 10, "displayMILVectors", false).get();
 
 		// VERIFY
@@ -117,7 +117,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(AnisotropyWrapper.class,
+		final CommandModule module = command().run(AnisotropyWrapper.class,
 			true, "inputImage", imgPlus, "lines", 10, "directions", 10).get();
 
 		// VERIFY
@@ -137,7 +137,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 	 */
 	@Test
 	public void testEllipsoidFittingFailingCancelsPlugins() throws Exception {
-		final CommandModule module = imageJ.command().run(AnisotropyWrapper.class,
+		final CommandModule module = command().run(AnisotropyWrapper.class,
 			true, "inputImage", hyperSheets, "lines", 4, "directions", 9).get();
 
 		assertTrue(module.isCanceled());
@@ -148,19 +148,19 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsWrapper() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			AnisotropyWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsWrapper() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			AnisotropyWrapper.class);
 	}
 
 	@Test
 	public void testTooFewPointsCancelsPlugin() throws Exception {
-		final CommandModule module = imageJ.command().run(AnisotropyWrapper.class,
+		final CommandModule module = command().run(AnisotropyWrapper.class,
 			true, "inputImage", hyperSheets, "lines", 1, "directions", 1).get();
 
 		assertTrue(module.isCanceled());
@@ -172,7 +172,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 	public void testMinimumIncrementIsEnforced() throws Exception {
 		final double expectedIncrement = Math.round(Math.sqrt(3.0) * 100.0) / 100.0;
 
-		final CommandModule module = imageJ.command()
+		final CommandModule module = command()
 				.run(AnisotropyWrapper.class, true, "inputImage", hyperSheets, "lines", 1,
 						"directions", 1, "samplingIncrement", 0).get();
 
@@ -184,7 +184,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 	public void testIncrementGreaterThanMinimumIsAllowd() throws Exception {
 		final double inputIncrement = 5.0;
 
-		final CommandModule module = imageJ.command()
+		final CommandModule module = command()
 				.run(AnisotropyWrapper.class, true, "inputImage", hyperSheets, "lines", 1,
 						"directions", 1, "samplingIncrement", inputIncrement).get();
 

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -181,7 +181,7 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 	}
 
 	@Test
-	public void testIncrementGreaterThanMinimumIsAllowd() throws Exception {
+	public void testIncrementGreaterThanMinimumIsAllowed() throws Exception {
 		final double inputIncrement = 5.0;
 
 		final CommandModule module = command()

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -39,7 +38,6 @@ import static org.scijava.ui.DialogPrompt.MessageType.INFORMATION_MESSAGE;
 import java.util.Arrays;
 import java.util.List;
 
-import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
@@ -48,19 +46,11 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
-import org.scijava.ui.UserInterface;
 import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 
 /**
@@ -69,33 +59,16 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class ConnectivityWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class ConnectivityWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		ConnectivityWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		ConnectivityWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void test2DImageCancelsConnectivity() {
-		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
 			ConnectivityWrapper.class);
 	}
 
@@ -103,7 +76,7 @@ public class ConnectivityWrapperTest {
 	public void testNegativeConnectivityShowsInfoDialog() throws Exception {
 		// Mock UI
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(mockUI.dialogPrompt(eq(NEGATIVE_CONNECTIVITY), anyString(), eq(
+		when(MOCK_UI.dialogPrompt(eq(NEGATIVE_CONNECTIVITY), anyString(), eq(
 			INFORMATION_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// Create a 3D hyperstack with two channels. Each channel has two particles
@@ -127,23 +100,23 @@ public class ConnectivityWrapperTest {
 		access.get().setOne();
 
 		// Run command
-		IMAGE_J.command().run(ConnectivityWrapper.class, true, "inputImage",
+		imageJ.command().run(ConnectivityWrapper.class, true, "inputImage",
 			imgPlus).get();
 
 		// Dialog should only be shown once
-		verify(mockUI, timeout(1000).times(1)).dialogPrompt(eq(
+		verify(MOCK_UI, timeout(1000).times(1)).dialogPrompt(eq(
 			NEGATIVE_CONNECTIVITY), anyString(), eq(INFORMATION_MESSAGE), any());
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsConnectivity() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
 			ConnectivityWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsConnectivity() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			ConnectivityWrapper.class);
 	}
 
@@ -187,7 +160,7 @@ public class ConnectivityWrapperTest {
 		access.get().setOne();
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			ConnectivityWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -207,10 +180,5 @@ public class ConnectivityWrapperTest {
 				assertEquals(expectedValues[i][j], column.get(j).doubleValue(),	1e-12);
 			}
 		}
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -177,7 +177,7 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 			assertEquals("A column has an incorrect header", expectedHeaders.get(i),
 				header);
 			for (int j = 0; j < column.size(); j++) {
-				assertEquals(expectedValues[i][j], column.get(j).doubleValue(),	1e-12);
+				assertEquals(expectedValues[i][j], column.get(j),	1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -52,9 +52,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
@@ -70,6 +72,7 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 public class ConnectivityWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
 	public static void oneTimeSetup() {
@@ -78,13 +81,20 @@ public class ConnectivityWrapperTest {
 		ConnectivityWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void test2DImageCancelsConnectivity() throws Exception {
+	public void test2DImageCancelsConnectivity() {
 		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
 			ConnectivityWrapper.class);
 	}
@@ -92,11 +102,9 @@ public class ConnectivityWrapperTest {
 	@Test
 	public void testNegativeConnectivityShowsInfoDialog() throws Exception {
 		// Mock UI
-		final UserInterface mockUI = mock(UserInterface.class);
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
 		when(mockUI.dialogPrompt(eq(NEGATIVE_CONNECTIVITY), anyString(), eq(
 			INFORMATION_MESSAGE), any())).thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// Create a 3D hyperstack with two channels. Each channel has two particles
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "mm");
@@ -128,13 +136,13 @@ public class ConnectivityWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsConnectivity() throws Exception {
+	public void testNonBinaryImageCancelsConnectivity() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			ConnectivityWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsConnectivity() throws Exception {
+	public void testNullImageCancelsConnectivity() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			ConnectivityWrapper.class);
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -68,7 +68,7 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsConnectivity() {
-		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ(),
 			ConnectivityWrapper.class);
 	}
 
@@ -100,7 +100,7 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 		access.get().setOne();
 
 		// Run command
-		imageJ.command().run(ConnectivityWrapper.class, true, "inputImage",
+		command().run(ConnectivityWrapper.class, true, "inputImage",
 			imgPlus).get();
 
 		// Dialog should only be shown once
@@ -110,13 +110,13 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsConnectivity() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			ConnectivityWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsConnectivity() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			ConnectivityWrapper.class);
 	}
 
@@ -160,7 +160,7 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 		access.get().setOne();
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			ConnectivityWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -51,9 +51,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
 import org.scijava.ui.UserInterface;
@@ -67,6 +69,7 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class ElementFractionWrapperTest {
 
+	private final UserInterface mockUI = mock(UserInterface.class);
 	private static final ImageJ IMAGE_J = new ImageJ();
 
 	@BeforeClass
@@ -76,19 +79,26 @@ public class ElementFractionWrapperTest {
 		ElementFractionWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsElementFraction() throws Exception {
+	public void testNonBinaryImageCancelsElementFraction() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			ElementFractionWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsElementFraction() throws Exception {
+	public void testNullImageCancelsElementFraction() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			ElementFractionWrapper.class);
 	}
@@ -205,11 +215,9 @@ public class ElementFractionWrapperTest {
 	@Test
 	public void testWeirdSpatialImageCancelsPlugin() throws Exception {
 		// Mock UI
-		final UserInterface mockUI = mock(UserInterface.class);
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
 		when(mockUI.dialogPrompt(anyString(), anyString(), any(), any()))
 			.thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// Create an hyperstack with no calibration
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -67,13 +67,13 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsElementFraction() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			ElementFractionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsElementFraction() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			ElementFractionWrapper.class);
 	}
 
@@ -113,7 +113,7 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 			calibration, units);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -164,7 +164,7 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 			calibration, units);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -201,7 +201,7 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 			cAxis);
 
 		// Run command
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		assertTrue("A non 2D and 3D image should have cancelled the plugin", module

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -36,7 +35,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
@@ -47,18 +45,11 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
-import org.scijava.ui.UserInterface;
 import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 
 /**
@@ -67,39 +58,22 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class ElementFractionWrapperTest {
-
-	private final UserInterface mockUI = mock(UserInterface.class);
-	private static final ImageJ IMAGE_J = new ImageJ();
+public class ElementFractionWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		ElementFractionWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		ElementFractionWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsElementFraction() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
 			ElementFractionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsElementFraction() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			ElementFractionWrapper.class);
 	}
 
@@ -139,7 +113,7 @@ public class ElementFractionWrapperTest {
 			calibration, units);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -190,7 +164,7 @@ public class ElementFractionWrapperTest {
 			calibration, units);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -216,7 +190,7 @@ public class ElementFractionWrapperTest {
 	public void testWeirdSpatialImageCancelsPlugin() throws Exception {
 		// Mock UI
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(mockUI.dialogPrompt(anyString(), anyString(), any(), any()))
+		when(MOCK_UI.dialogPrompt(anyString(), anyString(), any(), any()))
 			.thenReturn(mockPrompt);
 
 		// Create an hyperstack with no calibration
@@ -227,19 +201,14 @@ public class ElementFractionWrapperTest {
 			cAxis);
 
 		// Run command
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			ElementFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		assertTrue("A non 2D and 3D image should have cancelled the plugin", module
 			.isCanceled());
 		assertEquals("Cancel reason is incorrect", CommonMessages.WEIRD_SPATIAL,
 			module.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
@@ -54,19 +54,19 @@ public class FitEllipsoidWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsPlugin() {
-		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ(),
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
 	public void testAnisotropicImageShowsWarningDialog() {
-		CommonWrapperTests.testAnisotropyWarning(imageJ,
+		CommonWrapperTests.testAnisotropyWarning(imageJ(),
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			FitEllipsoidWrapper.class);
 	}
 
@@ -76,7 +76,7 @@ public class FitEllipsoidWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = NewImage.createImage("", 5, 5, 5, 8, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			FitEllipsoidWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
@@ -26,25 +26,15 @@ package org.bonej.wrapperPlugins;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import net.imagej.ImageJ;
 import net.imagej.ops.stats.regression.leastSquares.Quadric;
 
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
-import org.scijava.ui.UserInterface;
 
 import ij.ImagePlus;
 import ij.gui.NewImage;
@@ -55,33 +45,28 @@ import ij.gui.NewImage;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class FitEllipsoidWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class FitEllipsoidWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		FitEllipsoidWrapper.setReporter(mockReporter);
+		FitEllipsoidWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void test2DImageCancelsPlugin() {
-		CommonWrapperTests.test2DImagePlusCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ,
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
 	public void testAnisotropicImageShowsWarningDialog() {
-		CommonWrapperTests.testAnisotropyWarning(IMAGE_J,
+		CommonWrapperTests.testAnisotropyWarning(imageJ,
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			FitEllipsoidWrapper.class);
 	}
 
@@ -91,7 +76,7 @@ public class FitEllipsoidWrapperTest {
 		final ImagePlus imagePlus = NewImage.createImage("", 5, 5, 5, 8, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			FitEllipsoidWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -100,22 +85,7 @@ public class FitEllipsoidWrapperTest {
 		assertTrue("Cancel reason is incorrect", module.getCancelReason()
 			.startsWith("Please populate ROI Manager with at least " +
 				Quadric.MIN_DATA));
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
@@ -35,10 +35,13 @@ import net.imagej.ImageJ;
 import net.imagej.ops.stats.regression.leastSquares.Quadric;
 
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.ui.UserInterface;
@@ -55,6 +58,7 @@ import ij.gui.NewImage;
 public class FitEllipsoidWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
 	public static void oneTimeSetup() {
@@ -64,19 +68,19 @@ public class FitEllipsoidWrapperTest {
 	}
 
 	@Test
-	public void test2DImageCancelsPlugin() throws Exception {
+	public void test2DImageCancelsPlugin() {
 		CommonWrapperTests.test2DImagePlusCancelsPlugin(IMAGE_J,
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
-	public void testAnisotropicImageShowsWarningDialog() throws Exception {
+	public void testAnisotropicImageShowsWarningDialog() {
 		CommonWrapperTests.testAnisotropyWarning(IMAGE_J,
 			FitEllipsoidWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsPlugin() throws Exception {
+	public void testNullImageCancelsPlugin() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			FitEllipsoidWrapper.class);
 	}
@@ -84,7 +88,6 @@ public class FitEllipsoidWrapperTest {
 	@Test
 	public void testNullROIManagerCancelsPlugin() throws Exception {
 		// SETUP
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = NewImage.createImage("", 5, 5, 5, 8, 1);
 
 		// EXECUTE
@@ -99,6 +102,16 @@ public class FitEllipsoidWrapperTest {
 				Quadric.MIN_DATA));
 		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
+	}
+
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
+	@After
+	public void tearDown() {
+		Mockito.reset(mockUI);
 	}
 
 	@AfterClass

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -66,13 +66,13 @@ public class FractalDimensionWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsFractalDimension() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			FractalDimensionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsFractalDimension() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			FractalDimensionWrapper.class);
 	}
 
@@ -91,7 +91,7 @@ public class FractalDimensionWrapperTest extends AbstractWrapperTest {
 		final ImgPlus<BitType> imgPlus = createTestHyperStack("Test");
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			FractalDimensionWrapper.class, true, "inputImage", imgPlus,
 			"startBoxSize", 4, "smallestBoxSize", 2, "scaleFactor", 2.0,
 			"translations", 0L, "showPoints", true).get();
@@ -134,7 +134,7 @@ public class FractalDimensionWrapperTest extends AbstractWrapperTest {
 		final ImgPlus<BitType> imgPlus = createTestHyperStack(imageName);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			FractalDimensionWrapper.class, true, "inputImage", imgPlus,
 			"startBoxSize", 4, "smallestBoxSize", 1, "scaleFactor", 2.0,
 			"translations", 0L).get();

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -49,9 +49,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.Column;
@@ -59,6 +61,7 @@ import org.scijava.table.DefaultColumn;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.GenericTable;
 import org.scijava.table.Table;
+import org.scijava.ui.UserInterface;
 
 /**
  * Tests for {@link FractalDimensionWrapper}
@@ -69,6 +72,7 @@ import org.scijava.table.Table;
 public class FractalDimensionWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
 	public static void oneTimeSetup() {
@@ -77,19 +81,26 @@ public class FractalDimensionWrapperTest {
 		FractalDimensionWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsFractalDimension() throws Exception {
+	public void testNonBinaryImageCancelsFractalDimension() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			FractalDimensionWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsFractalDimension() throws Exception {
+	public void testNullImageCancelsFractalDimension() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			FractalDimensionWrapper.class);
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -25,9 +25,6 @@ package org.bonej.wrapperPlugins;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -35,7 +32,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
@@ -45,23 +41,15 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.Column;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.GenericTable;
 import org.scijava.table.Table;
-import org.scijava.ui.UserInterface;
 
 /**
  * Tests for {@link FractalDimensionWrapper}
@@ -69,39 +57,22 @@ import org.scijava.ui.UserInterface;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class FractalDimensionWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class FractalDimensionWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		FractalDimensionWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		FractalDimensionWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsFractalDimension() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
 			FractalDimensionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsFractalDimension() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			FractalDimensionWrapper.class);
 	}
 
@@ -120,7 +91,7 @@ public class FractalDimensionWrapperTest {
 		final ImgPlus<BitType> imgPlus = createTestHyperStack("Test");
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			FractalDimensionWrapper.class, true, "inputImage", imgPlus,
 			"startBoxSize", 4, "smallestBoxSize", 2, "scaleFactor", 2.0,
 			"translations", 0L, "showPoints", true).get();
@@ -163,7 +134,7 @@ public class FractalDimensionWrapperTest {
 		final ImgPlus<BitType> imgPlus = createTestHyperStack(imageName);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			FractalDimensionWrapper.class, true, "inputImage", imgPlus,
 			"startBoxSize", 4, "smallestBoxSize", 1, "scaleFactor", 2.0,
 			"translations", 0L).get();
@@ -182,11 +153,6 @@ public class FractalDimensionWrapperTest {
 			dimension, 1e-12));
 		table.get("R²").forEach(r2 -> assertEquals("R² column has a wrong value",
 			expectedRSquares.next(), r2, 1e-12));
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 
 	/** Create a hyperstack with a cuboid in two subspaces */

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -59,9 +59,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
@@ -78,16 +80,24 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 public class IntertrabecularAngleWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
-	public static void setup() {
+	public static void oneTimeSetup() {
 		final UsageReporter mockReporter = mock(UsageReporter.class);
 		doNothing().when(mockReporter).reportEvent(anyString());
 		IntertrabecularAngleWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
@@ -129,7 +139,7 @@ public class IntertrabecularAngleWrapperTest {
 	}
 
 	@Test
-	public void testAnisotropicImageShowsWarningDialog() throws Exception {
+	public void testAnisotropicImageShowsWarningDialog() {
 		CommonWrapperTests.testAnisotropyWarning(IMAGE_J,
 			IntertrabecularAngleWrapper.class);
 	}
@@ -139,7 +149,6 @@ public class IntertrabecularAngleWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_CHANNEL_DIMENSIONS +
 			". Please split the channels.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
@@ -185,11 +194,9 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testMultipleGraphsShowsWarningDialog() throws Exception {
 		// SETUP
-		final UserInterface mockUI = mock(UserInterface.class);
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
 		when(mockUI.dialogPrompt(startsWith("Image has multiple skeletons"),
 			anyString(), eq(WARNING_MESSAGE), any())).thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus pixels = NewImage.createByteImage("Test", 4, 4, 1,
 			FILL_BLACK);
 		pixels.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -211,9 +218,7 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testNoImageWhenNoSkeletonisation() throws Exception {
 		// SETUP
-		final UserInterface mockUI = mock(UserInterface.class);
 		doNothing().when(mockUI).show(any(ImagePlus.class));
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus pixel = NewImage.createByteImage("Test", 3, 3, 1,
 			FILL_BLACK);
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -232,7 +237,6 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testNoResultsCancelsPlugin() throws Exception {
 		// SETUP
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus pixel = NewImage.createByteImage("Test", 3, 3, 1,
 			FILL_BLACK);
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -253,7 +257,6 @@ public class IntertrabecularAngleWrapperTest {
 	public void testNoSkeletonsCancelsPlugin() throws Exception {
 		// SETUP
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 
 		// EXECUTE
 		final CommandModule module = IMAGE_J.command().run(
@@ -268,13 +271,13 @@ public class IntertrabecularAngleWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsPlugin() throws Exception {
+	public void testNonBinaryImageCancelsPlugin() {
 		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
 			IntertrabecularAngleWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsPlugin() throws Exception {
+	public void testNullImageCancelsPlugin() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			IntertrabecularAngleWrapper.class);
 	}
@@ -282,9 +285,7 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testPrintCentroids() throws Exception {
 		// SETUP
-		final UserInterface mockUI = mock(UserInterface.class);
 		doNothing().when(mockUI).show(any(ImagePlus.class));
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus line = NewImage.createByteImage("Test", 5, 3, 1,
 			FILL_BLACK);
 		line.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -324,9 +325,7 @@ public class IntertrabecularAngleWrapperTest {
 	@Test
 	public void testSkeletonImageWhenSkeletonised() throws Exception {
 		// SETUP
-		final UserInterface mockUI = mock(UserInterface.class);
 		doNothing().when(mockUI).show(any(ImagePlus.class));
-		IMAGE_J.ui().setDefaultUI(mockUI);
 		final ImagePlus square = NewImage.createByteImage("Test", 4, 4, 1,
 			FILL_BLACK);
 		square.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
@@ -347,7 +346,6 @@ public class IntertrabecularAngleWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_TIME_DIMENSIONS +
 			". Please split the hyperstack.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
@@ -362,6 +360,7 @@ public class IntertrabecularAngleWrapperTest {
 		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
+
 
 	@AfterClass
 	public static void oneTimeTearDown() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -86,7 +86,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final ImagePlus skelly = IJ.openImage(resource.getFile());
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", skelly,
 			"minimumValence", 3, "maximumValence", 50, "minimumTrabecularLength", 2,
 			"marginCutOff", 0, "useClusters", true, "iteratePruning", false).get();
@@ -115,7 +115,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testAnisotropicImageShowsWarningDialog() {
-		CommonWrapperTests.testAnisotropyWarning(imageJ,
+		CommonWrapperTests.testAnisotropyWarning(imageJ(),
 			IntertrabecularAngleWrapper.class);
 	}
 
@@ -127,7 +127,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -149,7 +149,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final ImagePlus skelly = IJ.openImage(resource.getFile());
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", skelly,
 			"minimumValence", 3, "maximumValence", 50, "minimumTrabecularLength", 2,
 			"marginCutOff", 10, "useClusters", true, "iteratePruning", false).get();
@@ -178,7 +178,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		pixels.getStack().getProcessor(1).set(3, 3, (byte) 0xFF);
 
 		// EXECUTE
-		imageJ.command().run(IntertrabecularAngleWrapper.class, true, "inputImage",
+		command().run(IntertrabecularAngleWrapper.class, true, "inputImage",
 			pixels).get();
 
 		// VERIFY
@@ -199,7 +199,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", pixel).get();
 
 		// VERIFY
@@ -217,7 +217,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", pixel).get();
 
 		// VERIFY
@@ -234,7 +234,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createImage("test", 3, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -247,13 +247,13 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ(),
 			IntertrabecularAngleWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			IntertrabecularAngleWrapper.class);
 	}
 
@@ -268,7 +268,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		line.getStack().getProcessor(1).set(3, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", line,
 			"minimumTrabecularLength", 0, "printCentroids", true).get();
 
@@ -309,7 +309,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		square.getStack().getProcessor(1).set(2, 2, (byte) 0xFF);
 
 		// EXECUTE
-		imageJ.command().run(IntertrabecularAngleWrapper.class, true, "inputImage",
+		command().run(IntertrabecularAngleWrapper.class, true, "inputImage",
 			square).get();
 
 		// VERIFY
@@ -324,7 +324,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			IntertrabecularAngleWrapper.class, true, "inputImage", imagePlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -54,7 +54,6 @@ import java.util.stream.Stream;
 
 import net.imagej.table.DefaultResultsTable;
 
-import org.bonej.utilities.SharedTable;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -107,9 +106,9 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		assertEquals(10, fiveColumn.size());
 		assertEquals(10, fiveColumn.stream().filter(nonEmpty).count());
 		assertEquals(6, fiveColumn.stream().filter(nonEmpty).distinct().count());
-		assertEquals(1, fiveColumn.stream().filter(nonEmpty).map(Double::valueOf)
+		assertEquals(1, fiveColumn.stream().filter(nonEmpty)
 			.filter(d -> d == Math.PI).count());
-		assertEquals(2, fiveColumn.stream().filter(nonEmpty).map(Double::valueOf)
+		assertEquals(2, fiveColumn.stream().filter(nonEmpty)
 			.filter(d -> d == Math.PI / 2).count());
 	}
 
@@ -142,7 +141,6 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 	@Test
 	public void testMargins() throws Exception {
 		// SETUP
-		final Predicate<Double> nonEmpty = s -> !s.equals(SharedTable.EMPTY_CELL);
 		final URL resource = getClass().getClassLoader().getResource(
 			"test-skelly.zip");
 		assert resource != null;
@@ -163,7 +161,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		final DefaultColumn<Double> fiveColumn = table.get(0);
 		assertEquals("5", fiveColumn.getHeader());
 		assertEquals(10, fiveColumn.size());
-		assertEquals(10, fiveColumn.stream().filter(nonEmpty).count());
+		assertEquals(10, fiveColumn.stream().filter(Objects::nonNull).count());
 	}
 
 	@Test

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
@@ -40,9 +40,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.ui.UserInterface;
@@ -61,16 +63,24 @@ import ij.measure.Calibration;
 public class SkeletoniseWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
-	public static void setup() {
+	public static void oneTimeSetup() {
 		final UsageReporter mockReporter = mock(UsageReporter.class);
 		doNothing().when(mockReporter).reportEvent(anyString());
 		SkeletoniseWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
@@ -79,7 +89,6 @@ public class SkeletoniseWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_CHANNEL_DIMENSIONS +
 			". Please split the channels.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
@@ -96,13 +105,13 @@ public class SkeletoniseWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsPlugin() throws Exception {
+	public void testNonBinaryImageCancelsPlugin() {
 		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
 			SkeletoniseWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsPlugin() throws Exception {
+	public void testNullImageCancelsPlugin() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			SkeletoniseWrapper.class);
 	}
@@ -136,7 +145,6 @@ public class SkeletoniseWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_TIME_DIMENSIONS +
 			". Please split the hyperstack.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
@@ -63,7 +63,7 @@ public class SkeletoniseWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -77,13 +77,13 @@ public class SkeletoniseWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ(),
 			SkeletoniseWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			SkeletoniseWrapper.class);
 	}
 
@@ -97,7 +97,7 @@ public class SkeletoniseWrapperTest extends AbstractWrapperTest {
 		imagePlus.setCalibration(calibration);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -119,7 +119,7 @@ public class SkeletoniseWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
@@ -29,25 +29,13 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import net.imagej.ImageJ;
-
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
-import org.scijava.ui.UserInterface;
 
 import ij.IJ;
 import ij.ImagePlus;
@@ -60,28 +48,11 @@ import ij.measure.Calibration;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class SkeletoniseWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class SkeletoniseWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		SkeletoniseWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		SkeletoniseWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
@@ -92,7 +63,7 @@ public class SkeletoniseWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -100,19 +71,19 @@ public class SkeletoniseWrapperTest {
 			.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
 			SkeletoniseWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			SkeletoniseWrapper.class);
 	}
 
@@ -126,7 +97,7 @@ public class SkeletoniseWrapperTest {
 		imagePlus.setCalibration(calibration);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -148,7 +119,7 @@ public class SkeletoniseWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(SkeletoniseWrapper.class,
+		final CommandModule module = imageJ.command().run(SkeletoniseWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -156,13 +127,7 @@ public class SkeletoniseWrapperTest {
 			module.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
-	}
-
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -50,7 +49,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
@@ -63,19 +61,11 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
-import org.scijava.ui.UserInterface;
 import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 
 /**
@@ -84,33 +74,16 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class SurfaceAreaWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		SurfaceAreaWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		SurfaceAreaWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void test2DImageCancelsIsosurface() {
-		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
 			SurfaceAreaWrapper.class);
 	}
 
@@ -131,17 +104,17 @@ public class SurfaceAreaWrapperTest {
 
 		// Mock UI
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
+		when(MOCK_UI.chooseFile(any(File.class), anyString())).thenReturn(
 			exceptionsThrowingFile);
-		when(mockUI.dialogPrompt(startsWith(STL_WRITE_ERROR), anyString(), eq(
+		when(MOCK_UI.dialogPrompt(startsWith(STL_WRITE_ERROR), anyString(), eq(
 			ERROR_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// Run plugin
-		IMAGE_J.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
+		imageJ.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
 			"exportSTL", true).get();
 
 		// Verify that write error dialog got shown
-		verify(mockUI, timeout(1000).times(1)).dialogPrompt(startsWith(
+		verify(MOCK_UI, timeout(1000).times(1)).dialogPrompt(startsWith(
 			STL_WRITE_ERROR), anyString(), eq(ERROR_MESSAGE), any());
 	}
 
@@ -228,27 +201,27 @@ public class SurfaceAreaWrapperTest {
 
 		// Mock UI
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(mockUI.dialogPrompt(eq(SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(
+		when(MOCK_UI.dialogPrompt(eq(SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(
 			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// Run plugin
-		IMAGE_J.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
+		imageJ.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
 			"exportSTL", false).get();
 
 		// Verify that warning dialog about result scaling got shown once
-		verify(mockUI, timeout(1000).times(1)).dialogPrompt(eq(
+		verify(MOCK_UI, timeout(1000).times(1)).dialogPrompt(eq(
 			SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(WARNING_MESSAGE), any());
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsIsosurface() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
 			SurfaceAreaWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsIsosurface() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			SurfaceAreaWrapper.class);
 	}
 
@@ -295,7 +268,7 @@ public class SurfaceAreaWrapperTest {
 		}
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(SurfaceAreaWrapper.class,
+		final CommandModule module = imageJ.command().run(SurfaceAreaWrapper.class,
 			true, "inputImage", imgPlus, "exportSTL", false).get();
 
 		// VERIFY
@@ -398,10 +371,5 @@ public class SurfaceAreaWrapperTest {
 		final Mesh mesh = new NaiveFloatMesh();
 
 		SurfaceAreaWrapper.writeBinarySTLFile(null, mesh);
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -67,9 +67,11 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
@@ -85,21 +87,29 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
 public class SurfaceAreaWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
-	public static void setup() {
+	public static void oneTimeSetup() {
 		final UsageReporter mockReporter = mock(UsageReporter.class);
 		doNothing().when(mockReporter).reportEvent(anyString());
 		SurfaceAreaWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void test2DImageCancelsIsosurface() throws Exception {
+	public void test2DImageCancelsIsosurface() {
 		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
 			SurfaceAreaWrapper.class);
 	}
@@ -120,13 +130,11 @@ public class SurfaceAreaWrapperTest {
 			yAxis, zAxis);
 
 		// Mock UI
-		final UserInterface mockUI = mock(UserInterface.class);
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
 		when(mockUI.chooseFile(any(File.class), anyString())).thenReturn(
 			exceptionsThrowingFile);
 		when(mockUI.dialogPrompt(startsWith(STL_WRITE_ERROR), anyString(), eq(
 			ERROR_MESSAGE), any())).thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// Run plugin
 		IMAGE_J.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
@@ -219,11 +227,9 @@ public class SurfaceAreaWrapperTest {
 			yAxis, zAxis, tAxis);
 
 		// Mock UI
-		final UserInterface mockUI = mock(UserInterface.class);
 		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
 		when(mockUI.dialogPrompt(eq(SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(
 			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
-		IMAGE_J.ui().setDefaultUI(mockUI);
 
 		// Run plugin
 		IMAGE_J.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
@@ -235,13 +241,13 @@ public class SurfaceAreaWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsIsosurface() throws Exception {
+	public void testNonBinaryImageCancelsIsosurface() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			SurfaceAreaWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsIsosurface() throws Exception {
+	public void testNullImageCancelsIsosurface() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			SurfaceAreaWrapper.class);
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -83,7 +83,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsIsosurface() {
-		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ(),
 			SurfaceAreaWrapper.class);
 	}
 
@@ -110,7 +110,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 			ERROR_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// Run plugin
-		imageJ.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
+		command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
 			"exportSTL", true).get();
 
 		// Verify that write error dialog got shown
@@ -205,7 +205,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
 
 		// Run plugin
-		imageJ.command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
+		command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
 			"exportSTL", false).get();
 
 		// Verify that warning dialog about result scaling got shown once
@@ -215,13 +215,13 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsIsosurface() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			SurfaceAreaWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsIsosurface() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			SurfaceAreaWrapper.class);
 	}
 
@@ -268,7 +268,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 		}
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(SurfaceAreaWrapper.class,
+		final CommandModule module = command().run(SurfaceAreaWrapper.class,
 			true, "inputImage", imgPlus, "exportSTL", false).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -283,7 +283,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 			assertEquals("A column has an incorrect header", expectedHeaders[i],
 				column.getHeader());
 			for (int j = 0; j < column.size(); j++) {
-				assertEquals("Column has an incorrect value", expectedValues[j], column.get(j).doubleValue(), 1e-12);
+				assertEquals("Column has an incorrect value", expectedValues[j], column.get(j), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -146,8 +146,8 @@ public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
 			assertEquals("Column has incorrect header", expectedHeaders[i], column
 				.getHeader());
 			for (int j = 0; j < expectedValues.length; j++) {
-				assertEquals("Incorrect value in table", expectedValues[i][j], 
-						column.get(j).doubleValue(), 1e-12);
+				assertEquals("Incorrect value in table", expectedValues[i][j],
+						column.get(j), 1e-12);
 			}
 		}
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -25,13 +25,9 @@ package org.bonej.wrapperPlugins;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
-import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
@@ -40,19 +36,11 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
-import org.scijava.ui.UserInterface;
 
 /**
  * Tests for the {@link SurfaceFractionWrapper} class
@@ -60,45 +48,28 @@ import org.scijava.ui.UserInterface;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class SurfaceFractionWrapperTest {
-
-	private final UserInterface mockUI = mock(UserInterface.class);
-	private static final Gateway IMAGE_J = new ImageJ();
+public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		SurfaceFractionWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		SurfaceFractionWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void test2DImageCancelsConnectivity() {
-		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsSurfaceFraction() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsSurfaceFraction() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			SurfaceFractionWrapper.class);
 	}
 
@@ -158,7 +129,7 @@ public class SurfaceFractionWrapperTest {
 		}
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(
+		final CommandModule module = imageJ.command().run(
 			SurfaceFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY
@@ -179,10 +150,5 @@ public class SurfaceFractionWrapperTest {
 						column.get(j).doubleValue(), 1e-12);
 			}
 		}
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -44,12 +44,15 @@ import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
+import org.scijava.ui.UserInterface;
 
 /**
  * Tests for the {@link SurfaceFractionWrapper} class
@@ -59,34 +62,42 @@ import org.scijava.table.DefaultColumn;
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class SurfaceFractionWrapperTest {
 
+	private final UserInterface mockUI = mock(UserInterface.class);
 	private static final Gateway IMAGE_J = new ImageJ();
 
 	@BeforeClass
-	public static void setup() {
+	public static void oneTimeSetup() {
 		final UsageReporter mockReporter = mock(UsageReporter.class);
 		doNothing().when(mockReporter).reportEvent(anyString());
 		SurfaceFractionWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void test2DImageCancelsConnectivity() throws Exception {
+	public void test2DImageCancelsConnectivity() {
 		CommonWrapperTests.test2DImageCancelsPlugin(IMAGE_J,
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsSurfaceFraction() throws Exception {
+	public void testNonBinaryImageCancelsSurfaceFraction() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(IMAGE_J,
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsSurfaceFraction() throws Exception {
+	public void testNullImageCancelsSurfaceFraction() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			SurfaceFractionWrapper.class);
 	}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -57,19 +57,19 @@ public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsConnectivity() {
-		CommonWrapperTests.test2DImageCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImageCancelsPlugin(imageJ(),
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
 	public void testNonBinaryImageCancelsSurfaceFraction() {
-		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),
 			SurfaceFractionWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsSurfaceFraction() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			SurfaceFractionWrapper.class);
 	}
 
@@ -129,7 +129,7 @@ public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
 		}
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(
+		final CommandModule module = command().run(
 			SurfaceFractionWrapper.class, true, "inputImage", imgPlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -65,13 +65,13 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void test2DImageCancelsPlugin() {
-		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ(),
 			ThicknessWrapper.class);
 	}
 
 	@Test
 	public void testAnisotropicImageShowsWarningDialog() {
-		CommonWrapperTests.testAnisotropyWarning(imageJ, ThicknessWrapper.class);
+		CommonWrapperTests.testAnisotropyWarning(imageJ(), ThicknessWrapper.class);
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -104,7 +104,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 			2, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", true)
 			.get();
 
@@ -127,7 +127,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", true)
 			.get();
 
@@ -144,7 +144,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", false)
 			.get();
 
@@ -161,7 +161,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Trabecular spacing",
 			"showMaps", true).get();
 
@@ -181,7 +181,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Trabecular thickness",
 			"showMaps", true).get();
 
@@ -196,13 +196,13 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ(),
 			ThicknessWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ(),
 			ThicknessWrapper.class);
 	}
 
@@ -221,7 +221,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 			Double.NaN }, { 10.392304420471191 }, { 0.0 }, { 10.392304420471191 } };
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "maskArtefacts",
 			false, "showMaps", false).get();
 
@@ -249,7 +249,7 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
+		final CommandModule module = command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -23,6 +23,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.bonej.wrapperPlugins;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -39,7 +40,6 @@ import ij.gui.NewImage;
 import ij.measure.Calibration;
 import ij.process.LUT;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -113,10 +113,10 @@ public class ThicknessWrapperTest extends AbstractWrapperTest {
 			.getLuts()[0];
 		final LUT spacingMap = ((ImagePlus) module.getOutput("spacingMap"))
 			.getLuts()[0];
-		assertTrue("Trabecular map doesn't have the 'fire' LUT", Arrays.equals(
-			fireLUT.getBytes(), trabecularMap.getBytes()));
-		assertTrue("Spacing map doesn't have the 'fire' LUT", Arrays.equals(fireLUT
-			.getBytes(), spacingMap.getBytes()));
+		assertArrayEquals("Trabecular map doesn't have the 'fire' LUT", fireLUT.getBytes(),
+				trabecularMap.getBytes());
+		assertArrayEquals("Spacing map doesn't have the 'fire' LUT", fireLUT
+				.getBytes(), spacingMap.getBytes());
 	}
 
 	@Test

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -52,9 +52,11 @@ import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
@@ -69,27 +71,35 @@ import org.scijava.ui.UserInterface;
 public class ThicknessWrapperTest {
 
 	private static final Gateway IMAGE_J = new ImageJ();
+	private final UserInterface mockUI = mock(UserInterface.class);
 
 	@BeforeClass
-	public static void setup() {
+	public static void oneTimeSetup() {
 		final UsageReporter mockReporter = mock(UsageReporter.class);
 		doNothing().when(mockReporter).reportEvent(anyString());
 		ThicknessWrapper.setReporter(mockReporter);
 	}
 
+	@Before
+	public void setup() {
+		IMAGE_J.ui().setDefaultUI(mockUI);
+	}
+
 	@After
 	public void tearDown() {
+		Mockito.reset(mockUI);
+
 		SharedTable.reset();
 	}
 
 	@Test
-	public void test2DImageCancelsPlugin() throws Exception {
+	public void test2DImageCancelsPlugin() {
 		CommonWrapperTests.test2DImagePlusCancelsPlugin(IMAGE_J,
 			ThicknessWrapper.class);
 	}
 
 	@Test
-	public void testAnisotropicImageShowsWarningDialog() throws Exception {
+	public void testAnisotropicImageShowsWarningDialog() {
 		CommonWrapperTests.testAnisotropyWarning(IMAGE_J, ThicknessWrapper.class);
 	}
 
@@ -98,7 +108,6 @@ public class ThicknessWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_CHANNEL_DIMENSIONS +
 			". Please split the channels.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
@@ -215,13 +224,13 @@ public class ThicknessWrapperTest {
 	}
 
 	@Test
-	public void testNonBinaryImageCancelsPlugin() throws Exception {
+	public void testNonBinaryImageCancelsPlugin() {
 		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
 			ThicknessWrapper.class);
 	}
 
 	@Test
-	public void testNullImageCancelsPlugin() throws Exception {
+	public void testNullImageCancelsPlugin() {
 		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
 			ThicknessWrapper.class);
 	}
@@ -266,7 +275,6 @@ public class ThicknessWrapperTest {
 		// SETUP
 		final String expectedMessage = CommonMessages.HAS_TIME_DIMENSIONS +
 			". Please split the hyperstack.";
-		final UserInterface mockUI = CommonWrapperTests.mockUIService(IMAGE_J);
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -30,8 +30,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -45,22 +43,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import net.imagej.ImageJ;
-
-import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
-import org.scijava.Gateway;
 import org.scijava.command.CommandModule;
 import org.scijava.table.DefaultColumn;
-import org.scijava.ui.UserInterface;
 
 /**
  * Tests for {@link ThicknessWrapper}
@@ -68,39 +56,22 @@ import org.scijava.ui.UserInterface;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class ThicknessWrapperTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
-	private final UserInterface mockUI = mock(UserInterface.class);
+public class ThicknessWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		final UsageReporter mockReporter = mock(UsageReporter.class);
-		doNothing().when(mockReporter).reportEvent(anyString());
-		ThicknessWrapper.setReporter(mockReporter);
-	}
-
-	@Before
-	public void setup() {
-		IMAGE_J.ui().setDefaultUI(mockUI);
-	}
-
-	@After
-	public void tearDown() {
-		Mockito.reset(mockUI);
-
-		SharedTable.reset();
+		ThicknessWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	@Test
 	public void test2DImageCancelsPlugin() {
-		CommonWrapperTests.test2DImagePlusCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.test2DImagePlusCancelsPlugin(imageJ,
 			ThicknessWrapper.class);
 	}
 
 	@Test
 	public void testAnisotropicImageShowsWarningDialog() {
-		CommonWrapperTests.testAnisotropyWarning(IMAGE_J, ThicknessWrapper.class);
+		CommonWrapperTests.testAnisotropyWarning(imageJ, ThicknessWrapper.class);
 	}
 
 	@Test
@@ -111,7 +82,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 3, 3, 1, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -119,7 +90,7 @@ public class ThicknessWrapperTest {
 			.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
 	}
 
@@ -133,7 +104,7 @@ public class ThicknessWrapperTest {
 			2, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", true)
 			.get();
 
@@ -156,7 +127,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", true)
 			.get();
 
@@ -173,7 +144,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "showMaps", false)
 			.get();
 
@@ -190,7 +161,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Trabecular spacing",
 			"showMaps", true).get();
 
@@ -210,7 +181,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = NewImage.createByteImage("image", 2, 2, 2, 1);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Trabecular thickness",
 			"showMaps", true).get();
 
@@ -225,13 +196,13 @@ public class ThicknessWrapperTest {
 
 	@Test
 	public void testNonBinaryImageCancelsPlugin() {
-		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNonBinaryImagePlusCancelsPlugin(imageJ,
 			ThicknessWrapper.class);
 	}
 
 	@Test
 	public void testNullImageCancelsPlugin() {
-		CommonWrapperTests.testNullImageCancelsPlugin(IMAGE_J,
+		CommonWrapperTests.testNullImageCancelsPlugin(imageJ,
 			ThicknessWrapper.class);
 	}
 
@@ -250,7 +221,7 @@ public class ThicknessWrapperTest {
 			Double.NaN }, { 10.392304420471191 }, { 0.0 }, { 10.392304420471191 } };
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus, "mapChoice", "Both", "maskArtefacts",
 			false, "showMaps", false).get();
 
@@ -278,7 +249,7 @@ public class ThicknessWrapperTest {
 		final ImagePlus imagePlus = IJ.createHyperStack("test", 3, 3, 1, 3, 3, 8);
 
 		// EXECUTE
-		final CommandModule module = IMAGE_J.command().run(ThicknessWrapper.class,
+		final CommandModule module = imageJ.command().run(ThicknessWrapper.class,
 			true, "inputImage", imagePlus).get();
 
 		// VERIFY
@@ -286,12 +257,7 @@ public class ThicknessWrapperTest {
 			module.isCanceled());
 		assertEquals("Cancel reason is incorrect", expectedMessage, module
 			.getCancelReason());
-		verify(mockUI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
+		verify(MOCK_UI, timeout(1000)).dialogPrompt(anyString(), anyString(), any(),
 			any());
-	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
 	}
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
@@ -26,13 +26,10 @@ package org.bonej.wrapperPlugins.tableTools;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import net.imagej.ImageJ;
-
 import org.bonej.utilities.SharedTable;
-import org.junit.AfterClass;
+import org.bonej.wrapperPlugins.AbstractWrapperTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.scijava.Gateway;
 
 /**
  * Tests for {@link SharedTableCleaner}
@@ -40,9 +37,7 @@ import org.scijava.Gateway;
  * @author Richard Domander
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
-public class SharedTableCleanerTest {
-
-	private static final Gateway IMAGE_J = new ImageJ();
+public class SharedTableCleanerTest extends AbstractWrapperTest {
 
 	@Test
 	public void testRun() throws Exception {
@@ -52,15 +47,9 @@ public class SharedTableCleanerTest {
 			.hasData());
 
 		// EXECUTE
-		IMAGE_J.command().run(SharedTableCleaner.class, true).get();
+		imageJ.command().run(SharedTableCleaner.class, true).get();
 
 		// VERIFY
 		assertFalse("Table should have no data", SharedTable.hasData());
 	}
-
-	@AfterClass
-	public static void oneTimeTearDown() {
-		IMAGE_J.context().dispose();
-	}
-
 }

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/tableTools/SharedTableCleanerTest.java
@@ -47,7 +47,7 @@ public class SharedTableCleanerTest extends AbstractWrapperTest {
 			.hasData());
 
 		// EXECUTE
-		imageJ.command().run(SharedTableCleaner.class, true).get();
+		command().run(SharedTableCleaner.class, true).get();
 
 		// VERIFY
 		assertFalse("Table should have no data", SharedTable.hasData());


### PR DESCRIPTION
Calculates minimum increment for Anisotropy dynamically based on pixel size, as suggested in PR #197. For now it's just `sqrt(3)` because the plugin doesn't yet handle calibration, but the necessary callbacks are now there for the future.

Also fixes problems in wrapper tests that I noticed when adding new tests for minimum increment. Basically mocking was handled sloppily, mock behaviour wasn't properly reset between tests etc.