### PR TITLE
Fix issue #195

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/DebugLauncher.java
+++ b/Legacy/bonej/src/main/java/org/bonej/DebugLauncher.java
@@ -1,0 +1,33 @@
+package org.bonej;
+
+import ij.IJ;
+import ij.ImageJ;
+import ij.ImagePlus;
+
+/**
+ * Launches legacy ImageJ for debugging (and a BoneJ plugin).
+ *
+ * @author Richard Domander
+ * @author dscho
+ */
+class DebugLauncher {
+    public static void main(String[] args) {
+        // set the plugins.dir property to make the plugin appear in the Plugins menu
+        /*
+        Class<?> clazz = SliceGeometry.class;
+        String url = clazz.getResource("/" + clazz.getName().replace('.', '/') + ".class").toString();
+        String pluginsDir = url.substring(5, url.length() - clazz.getName().length() - 6);
+        System.setProperty("plugins.dir", pluginsDir);
+        */
+
+        // start ImageJ
+        new ImageJ();
+
+        // open the Bat cochlea sample image
+        final ImagePlus image = IJ.openImage("https://imagej.net/images/bat-cochlea-volume.zip");
+        image.show();
+
+        // run the plugin
+        // IJ.runPlugIn(clazz.getName(), "");
+    }
+}

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
@@ -251,11 +251,11 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 	@Override
 	public void close() {
 		super.close();
-		if (WindowManager.getImageCount() == 0) return;
 		// clear the orientation overlay from open images
 		for (final Integer i : thetaHash.keySet()) {
 			WindowManager.getImage(i).setOverlay(null);
 		}
+		instance = null;
 	}
 
 	@Override

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
@@ -127,7 +127,7 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 	private boolean isReflected0;
 	private boolean isReflected1;
 
-	private Orienteer() {
+	public Orienteer() {
 		super("Orientation");
 		if (instance != null) {
 			if (instance.getTitle().equals(getTitle())) {

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
@@ -88,7 +88,7 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 							"axial", "abaxial", "Ax", "Ab" }, { "north", "south", "N", "S" },
 		{ "east", "west", "E", "W" }, { "up", "down", "Up", "D" }, { "right",
 			"left", "R", "L" } };
-	private static Orienteer instance = new Orienteer();
+	private static Orienteer instance;
 	private final Map<Integer, Double> thetaHash = new HashMap<>();
 	private final Map<Integer, Integer> lengthHash = new HashMap<>();
 	private final Map<Integer, Point> centreHash = new HashMap<>();

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
@@ -234,6 +234,8 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 		if (WindowManager.getImageCount() == 0) return;
 		final ImagePlus imp = WindowManager.getCurrentImage();
 		setup(imp);
+
+		UsageReporter.reportEvent(this).send();
 	}
 
 	@Override
@@ -505,7 +507,6 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 		final boolean[] units = { deg.getState(), rad.getState() };
 		unitHash.put(id, units);
 		updateTextbox();
-		UsageReporter.reportEvent(this).send();
 	}
 
 	private void update() {

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Orienteer.java
@@ -51,8 +51,10 @@ import java.awt.event.WindowEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.GeneralPath;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import ij.IJ;
 import ij.ImagePlus;
@@ -89,13 +91,13 @@ public final class Orienteer extends PlugInFrame implements AdjustmentListener,
 		{ "east", "west", "E", "W" }, { "up", "down", "Up", "D" }, { "right",
 			"left", "R", "L" } };
 	private static Orienteer instance;
-	private final Map<Integer, Double> thetaHash = new HashMap<>();
-	private final Map<Integer, Integer> lengthHash = new HashMap<>();
-	private final Map<Integer, Point> centreHash = new HashMap<>();
-	private final Map<Integer, GeneralPath> pathHash = new HashMap<>();
-	private final Map<Integer, int[]> axisHash = new HashMap<>();
-	private final Map<Integer, boolean[]> reflectHash = new HashMap<>();
-	private final Map<Integer, boolean[]> unitHash = new HashMap<>();
+	private final Map<Integer, Double> thetaHash = new Hashtable<>();
+	private final Map<Integer, Integer> lengthHash = new Hashtable<>();
+	private final Map<Integer, Point> centreHash = new Hashtable<>();
+	private final Map<Integer, GeneralPath> pathHash = new Hashtable<>();
+	private final Map<Integer, int[]> axisHash = new Hashtable<>();
+	private final Map<Integer, boolean[]> reflectHash = new Hashtable<>();
+	private final Map<Integer, boolean[]> unitHash = new Hashtable<>();
 	private final Overlay overlay = new Overlay();
 	private final int fontSize = 12;
 	private final Scrollbar slider = new Scrollbar(Scrollbar.HORIZONTAL, 0, 1, 0,

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
@@ -30,6 +30,7 @@ import java.awt.Rectangle;
 import java.awt.TextField;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Vector;
 
 import org.bonej.menuWrappers.LocalThickness;
 import org.bonej.util.BoneList;
@@ -183,13 +184,6 @@ public class SliceGeometry implements PlugIn, DialogListener {
 		if (isHUCalibrated) DialogModifier.replaceUnitString(gd, "grey", "HU");
 		else DialogModifier.replaceUnitString(gd, "HU", "grey");
 
-		final Checkbox oriented = (Checkbox) checkboxes.get(9);
-		if (orienteer == null) {
-			oriented.setState(false);
-			oriented.setEnabled(false);
-		}
-		else oriented.setEnabled(true);
-
 		DialogModifier.registerMacroValues(gd, gd.getComponents());
 		return true;
 	}
@@ -233,7 +227,7 @@ public class SliceGeometry implements PlugIn, DialogListener {
 		gd.addCheckbox("3D_Annotation", false);
 		gd.addCheckbox("Process_Stack", false);
 		gd.addCheckbox("Clear_results", false);
-		gd.addCheckbox("Use_Orientation", (orienteer != null));
+		initOrientationCheckBox(gd);
 		gd.addCheckbox("HU_Calibrated", ImageCheck.huCalibrated(imp));
 		gd.addNumericField("Bone_Min:", thresholds[0], 1, 6, pixUnits + " ");
 		gd.addNumericField("Bone_Max:", thresholds[1], 1, 6, pixUnits + " ");
@@ -370,6 +364,13 @@ public class SliceGeometry implements PlugIn, DialogListener {
 			show3DAxes(imp);
 		}
 		UsageReporter.reportEvent(this).send();
+	}
+
+	private void initOrientationCheckBox(final GenericDialog gd) {
+		gd.addCheckbox("Use_Orientation", (orienteer != null));
+		final Checkbox checkBox = (Checkbox) gd.getCheckboxes().lastElement();
+		checkBox.setState(orienteer != null);
+		checkBox.setEnabled(orienteer != null);
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes issue #195.

In addition it
* Makes the constructor `Orienteer()` `public` again so that the plugin can be run.
* Makes sure that `Orienteer` only calls `UsageReporter` when it's launched as a plugin (and calls it once per run)

@mdoube Since you understand these plugins much better, would you mind checking that they work correctly?