### PR TITLE
Include a specific version for LocalThickness_ (4.0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <license.copyrightOwners>Michael Doube, BoneJ developers</license.copyrightOwners>
         <releaseProfiles>deploy-to-scijava</releaseProfiles>
         <tagNameFormat>bonej-@{project.version}</tagNameFormat>
+        <LocalThickness_.version>4.0.3</LocalThickness_.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
- as recommended in issue #193

Advice is to put Maven version properties in the top-level POM.
