### PR TITLE
Move repeated code to an abstract base class

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -51,21 +51,15 @@ import org.apache.commons.math3.util.MathArrays;
 import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ImagePlusUtil;
 import org.bonej.utilities.SharedTable;
-import org.bonej.wrapperPlugins.wrapperUtils.Common;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandService;
-import org.scijava.command.ContextCommand;
 import org.scijava.convert.ConvertService;
 import org.scijava.io.IOService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginService;
-import org.scijava.prefs.PrefService;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.DoubleColumn;
@@ -89,13 +83,11 @@ import sc.fiji.skeletonize3D.Skeletonize3D_;
  * @author Richard Domander
  */
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Analyse Skeleton")
-public class AnalyseSkeletonWrapper extends ContextCommand {
+public class AnalyseSkeletonWrapper extends BoneJCommand {
 
 	static {
 		LegacyInjector.preinit();
 	}
-
-	private static UsageReporter reporter;
 
 	@Parameter(label = "Input image", validater = "validateImage",
 		persist = false)
@@ -186,13 +178,6 @@ public class AnalyseSkeletonWrapper extends ContextCommand {
 	@Parameter
 	private StatusService statusService;
 
-	@Parameter
-	private PrefService prefService;
-	@Parameter
-	private PluginService pluginService;
-	@Parameter
-	private CommandService commandService;
-
 	private ImagePlus intensityImage;
 
 	@Override
@@ -232,17 +217,7 @@ public class AnalyseSkeletonWrapper extends ContextCommand {
 				shortestPaths.setCalibration(inputImage.getCalibration());
 			}
 		}
-		if (reporter == null) {
-			reporter = UsageReporter.getInstance(prefService, pluginService, commandService);
-		}
-		reporter.reportEvent(getClass().getName());
-	}
-
-	static void setReporter(final UsageReporter reporter) {
-		if (reporter == null) {
-			throw new NullPointerException("Reporter cannot be null");
-		}
-		AnalyseSkeletonWrapper.reporter = reporter;
+		reportUsage();
 	}
 
 	private boolean hasNoSkeletons(final AnalyzeSkeleton_ analyzeSkeleton_) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/BoneJCommand.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/BoneJCommand.java
@@ -1,0 +1,45 @@
+package org.bonej.wrapperPlugins;
+
+import java.util.List;
+
+import net.imagej.ImgPlus;
+import net.imagej.ops.OpService;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.ComplexType;
+
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
+import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils;
+import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
+import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
+import org.scijava.command.CommandService;
+import org.scijava.command.ContextCommand;
+import org.scijava.plugin.PluginService;
+import org.scijava.prefs.PrefService;
+
+import static java.util.stream.Collectors.toList;
+
+public abstract class BoneJCommand extends ContextCommand {
+    private static UsageReporter reporter;
+    protected List<Subspace<BitType>> subspaces;
+
+    protected <C extends ComplexType<C>> List<Subspace<BitType>> find3DSubspaces(
+            final ImgPlus<C> image) {
+        final OpService opService = context().getService(OpService.class);
+        final ImgPlus<BitType> bitImgPlus = Common.toBitTypeImgPlus(opService, image);
+        return HyperstackUtils.split3DSubspaces(bitImgPlus).collect(toList());
+    }
+
+    protected void reportUsage() {
+        if (reporter == null) {
+            final PrefService prefService = context().getService(PrefService.class);
+            final PluginService pluginService = context().getService(PluginService.class);
+            final CommandService commandService = context().getService(CommandService.class);
+            reporter = UsageReporter.getInstance(prefService, pluginService, commandService);
+        }
+        reporter.reportEvent(getClass().getName());
+    }
+
+    static void setReporter(final UsageReporter reporter) {
+        BoneJCommand.reporter = reporter;
+    }
+}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -121,7 +121,7 @@ import sc.fiji.skeletonize3D.Skeletonize3D_;
  */
 
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Ellipsoid Factor")
-public class EllipsoidFactorWrapper extends ContextCommand {
+public class EllipsoidFactorWrapper extends BoneJCommand {
 
 	private static final String NO_ELLIPSOIDS_FOUND = "No ellipsoids were found - try modifying input parameters.";
 
@@ -294,7 +294,7 @@ public class EllipsoidFactorWrapper extends ContextCommand {
 		SharedTable.add(inputImage.getName(), "Min EF", min);
 		addResults(totalEllipsoids, fillingPercentage);
 		statusService.showStatus("Ellipsoid Factor completed");
-
+		reportUsage();
 	}
 
 	private List<ImgPlus> divideOutput(final List<ImgPlus> outputList, final int repetitions) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -48,19 +48,14 @@ import org.bonej.utilities.RoiManagerUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.joml.Matrix4dc;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandService;
-import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginService;
-import org.scijava.prefs.PrefService;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.Table;
 import org.scijava.ui.UIService;
@@ -73,7 +68,7 @@ import org.scijava.ui.UIService;
  * @author Richard Domander
  */
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Fit ellipsoid")
-public class FitEllipsoidWrapper extends ContextCommand {
+public class FitEllipsoidWrapper extends BoneJCommand {
 
 	static {
 		// NB: Needed if you mix-and-match IJ1 and IJ2 in a class.
@@ -101,15 +96,8 @@ public class FitEllipsoidWrapper extends ContextCommand {
 	private StatusService statusService;
 	@Parameter
 	private UIService uiService;
-	@Parameter
-	private PrefService prefs;
-	@Parameter
-	private PluginService pluginService;
-	@Parameter
-	private CommandService commandService;
 
 	private List<Vector3d> points;
-	private static UsageReporter reporter;
 
 	@Override
 	public void run() {
@@ -135,17 +123,7 @@ public class FitEllipsoidWrapper extends ContextCommand {
 		if (SharedTable.hasData()) {
 			resultsTable = SharedTable.getTable();
 		}
-		if (reporter == null) {
-			reporter = UsageReporter.getInstance(prefs, pluginService, commandService);
-		}
-		reporter.reportEvent(getClass().getName());
-	}
-
-	static void setReporter(final UsageReporter reporter) {
-		if (reporter == null) {
-			throw new NullPointerException("Reporter cannot be null");
-		}
-		FitEllipsoidWrapper.reporter = reporter;
+		reportUsage();
 	}
 
 	private void addResults(final Ellipsoid ellipsoid) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -51,18 +51,13 @@ import org.bonej.utilities.ImagePlusUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.joml.Vector3d;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandService;
-import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginService;
-import org.scijava.prefs.PrefService;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.Table;
@@ -93,7 +88,7 @@ import sc.fiji.skeletonize3D.Skeletonize3D_;
  */
 
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Inter-trabecular angles")
-public class IntertrabecularAngleWrapper extends ContextCommand {
+public class IntertrabecularAngleWrapper extends BoneJCommand {
 
 	public static final String NO_RESULTS_MSG =
 		"There were no results - try changing valence range or minimum trabecular length";
@@ -161,16 +156,9 @@ public class IntertrabecularAngleWrapper extends ContextCommand {
 	private StatusService statusService;
 	@Parameter
 	private UIService uiService;
-	@Parameter
-	private PrefService prefs;
-	@Parameter
-	private PluginService pluginService;
-	@Parameter
-	private CommandService commandService;
 
 	private double[] coefficients;
 	private boolean anisotropyWarned;
-	private static UsageReporter reporter;
 
 	@Override
 	public void run() {
@@ -204,17 +192,7 @@ public class IntertrabecularAngleWrapper extends ContextCommand {
 		addResults(radianMap);
 		printEdgeCentroids(cleanGraph.getEdges());
 		printCulledEdgePercentages(pruningResult.b);
-		if (reporter == null) {
-			reporter = UsageReporter.getInstance(prefs, pluginService, commandService);
-		}
-		reporter.reportEvent(getClass().getName());
-	}
-
-	static void setReporter(final UsageReporter reporter) {
-		if (reporter == null) {
-			throw new NullPointerException("Reporter cannot be null");
-		}
-		IntertrabecularAngleWrapper.reporter = reporter;
+		reportUsage();
 	}
 
 	private void addResults(final Map<Integer, DoubleStream> anglesMap) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SkeletoniseWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SkeletoniseWrapper.java
@@ -33,19 +33,14 @@ import static org.bonej.wrapperPlugins.wrapperUtils.Common.cancelMacroSafe;
 import net.imagej.patcher.LegacyInjector;
 
 import org.bonej.utilities.ImagePlusUtil;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandService;
-import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import ij.ImagePlus;
 import ij.plugin.filter.PlugInFilter;
-import org.scijava.plugin.PluginService;
-import org.scijava.prefs.PrefService;
 import sc.fiji.skeletonize3D.Skeletonize3D_;
 
 /**
@@ -54,7 +49,7 @@ import sc.fiji.skeletonize3D.Skeletonize3D_;
  * @author Richard Domander
  */
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Skeletonise")
-public class SkeletoniseWrapper extends ContextCommand {
+public class SkeletoniseWrapper extends BoneJCommand {
 
 	static {
 		LegacyInjector.preinit();
@@ -75,13 +70,6 @@ public class SkeletoniseWrapper extends ContextCommand {
 
 	@Parameter
 	private StatusService statusService;
-	@Parameter
-	private PrefService prefs;
-	@Parameter
-	private PluginService pluginService;
-	@Parameter
-	private CommandService commandService;
-	private static UsageReporter reporter;
 
 	@Override
 	public void run() {
@@ -91,17 +79,7 @@ public class SkeletoniseWrapper extends ContextCommand {
 		statusService.showStatus("Skeletonise: skeletonising");
 		skeletoniser.setup("", skeleton);
 		skeletoniser.run(null);
-		if (reporter == null) {
-			reporter = UsageReporter.getInstance(prefs, pluginService, commandService);
-		}
-		reporter.reportEvent(getClass().getName());
-	}
-
-	static void setReporter(final UsageReporter reporter) {
-		if (reporter == null) {
-			throw new NullPointerException("Reporter cannot be null");
-		}
-		SkeletoniseWrapper.reporter = reporter;
+		reportUsage();
 	}
 
 	@SuppressWarnings("unused")

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -46,16 +46,11 @@ import org.bonej.utilities.ImagePlusUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandService;
-import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.plugin.PluginService;
-import org.scijava.prefs.PrefService;
 import org.scijava.table.DefaultColumn;
 import org.scijava.table.Table;
 import org.scijava.ui.UIService;
@@ -69,7 +64,7 @@ import sc.fiji.localThickness.LocalThicknessWrapper;
  * @author Richard Domander
  */
 @Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Thickness")
-public class ThicknessWrapper extends ContextCommand {
+public class ThicknessWrapper extends BoneJCommand {
 
 	static {
 		LegacyInjector.preinit();
@@ -113,17 +108,10 @@ public class ThicknessWrapper extends ContextCommand {
 	private UIService uiService;
 	@Parameter
 	private StatusService statusService;
-	@Parameter
-	private PrefService prefs;
-	@Parameter
-	private PluginService pluginService;
-	@Parameter
-	private CommandService commandService;
 
 	private boolean foreground;
 	private LocalThicknessWrapper localThickness;
 	private boolean anisotropyWarned;
-	private static UsageReporter reporter;
 
 	@Override
 	public void run() {
@@ -156,17 +144,7 @@ public class ThicknessWrapper extends ContextCommand {
 				spacingMap.setLut(fire);
 			}
 		}
-		if (reporter == null) {
-			reporter = UsageReporter.getInstance(prefs, pluginService, commandService);
-		}
-		reporter.reportEvent(getClass().getName());
-	}
-
-	static void setReporter(final UsageReporter reporter) {
-		if (reporter == null) {
-			throw new NullPointerException("Reporter cannot be null");
-		}
-		ThicknessWrapper.reporter = reporter;
+		reportUsage();
 	}
 
 	private void addMapResults(final ImagePlus map) {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
@@ -63,6 +63,7 @@ public abstract class AbstractWrapperTest {
     public static void basicOneTimeSetup() {
         imageJ = new ImageJ();
         commandService = imageJ.command();
+        BoneJCommand.setReporter(MOCK_REPORTER);
     }
 
     @Before
@@ -80,6 +81,7 @@ public abstract class AbstractWrapperTest {
 
     @AfterClass
     public static void basicOneTimeTearDown() {
+        BoneJCommand.setReporter(null);
         imageJ.context().dispose();
         imageJ = null;
         commandService = null;

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapperTest.java
@@ -48,7 +48,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -459,11 +458,6 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		verify(MOCK_REPORTER, timeout(1000).times(0)).reportEvent(anyString());
 	}
 
-	@Test(expected = NullPointerException.class)
-	public void testSetReporterThrowsNPEIfNull() {
-		AnalyseSkeletonWrapper.setReporter(null);
-	}
-
 	@Test
 	public void testSuccessfulRunReports() throws ExecutionException,
 		InterruptedException
@@ -480,11 +474,6 @@ public class AnalyseSkeletonWrapperTest extends AbstractWrapperTest {
 		// VERIFY
 		assertFalse("Sanity check failed: method cancelled", module.isCanceled());
 		verify(MOCK_REPORTER, timeout(1000)).reportEvent(anyString());
-	}
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		AnalyseSkeletonWrapper.setReporter(MOCK_REPORTER);
 	}
 
 	private void mockIntensityFileOpening(final String path) {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AnisotropyWrapperTest.java
@@ -197,8 +197,6 @@ public class AnisotropyWrapperTest extends AbstractWrapperTest {
 
 	@BeforeClass
 	public static void oneTimeSetup() {
-		AnisotropyWrapper.setReporter(MOCK_REPORTER);
-
 		final String unit = "mm";
 		final double scale = 1.0;
 		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, unit, scale);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -46,7 +46,6 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -60,11 +59,6 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class ConnectivityWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		ConnectivityWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void test2DImageCancelsConnectivity() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -45,7 +45,6 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.view.Views;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -59,11 +58,6 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class ElementFractionWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		ElementFractionWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void testNonBinaryImageCancelsElementFraction() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FitEllipsoidWrapperTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.verify;
 
 import net.imagej.ops.stats.regression.leastSquares.Quadric;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -46,11 +45,6 @@ import ij.gui.NewImage;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class FitEllipsoidWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		FitEllipsoidWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void test2DImageCancelsPlugin() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/FractalDimensionWrapperTest.java
@@ -41,7 +41,6 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -58,12 +57,6 @@ import org.scijava.table.Table;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class FractalDimensionWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		FractalDimensionWrapper.setReporter(MOCK_REPORTER);
-	}
-
 	@Test
 	public void testNonBinaryImageCancelsFractalDimension() {
 		CommonWrapperTests.testNonBinaryImageCancelsPlugin(imageJ(),

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -54,7 +54,6 @@ import java.util.stream.Stream;
 
 import net.imagej.table.DefaultResultsTable;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -69,11 +68,6 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		IntertrabecularAngleWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void testAngleResults() throws Exception {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SkeletoniseWrapperTest.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -49,11 +48,6 @@ import ij.measure.Calibration;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class SkeletoniseWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		SkeletoniseWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void testCompositeImageCancelsPlugin() throws Exception {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -61,7 +61,6 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -75,11 +74,6 @@ import org.scijava.ui.swing.sdi.SwingDialogPrompt;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		SurfaceAreaWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void test2DImageCancelsIsosurface() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -36,7 +36,6 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.logic.BitType;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -49,11 +48,6 @@ import org.scijava.table.DefaultColumn;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		SurfaceFractionWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void test2DImageCancelsConnectivity() {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ThicknessWrapperTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.bonej.wrapperPlugins.wrapperUtils.Common;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.scijava.command.CommandModule;
@@ -57,11 +56,6 @@ import org.scijava.table.DefaultColumn;
  */
 @Category(org.bonej.wrapperPlugins.SlowWrapperTest.class)
 public class ThicknessWrapperTest extends AbstractWrapperTest {
-
-	@BeforeClass
-	public static void oneTimeSetup() {
-		ThicknessWrapper.setReporter(MOCK_REPORTER);
-	}
 
 	@Test
 	public void test2DImageCancelsPlugin() {


### PR DESCRIPTION
* Creates an abstract base class `BoneJCommand` that all wrapper plugins extend
* Moves shared functionality to the base class

As a side note I tried moving the common output 
```
@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
private Table<DefaultColumn<Double>, Double> resultsTable;
```
but that doesn't seem to be possible (tests started to throw `NullPointerException`).

I checked that `mvn test -PallTests` passes, and manually ran all the modern plugins.