### PR TITLE
Move results table to BoneJCommand

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -60,12 +60,10 @@ import org.scijava.io.IOService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.IntColumn;
 import org.scijava.table.PrimitiveColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 import org.scijava.widget.ChoiceWidget;
 import org.scijava.widget.FileWidget;
@@ -131,13 +129,6 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 		description = "Show skeleton images labelled with their IDs",
 		required = false)
 	private boolean displaySkeletons;
-
-	/**
-	 * The results of the analysis in a {@link Table}, null if there are no
-	 * results.
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>,Double> resultsTable;
 
 	/**
 	 * Additional analysis details in a {@link DefaultGenericTable}, null if

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -366,9 +366,7 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 			SharedTable.add(label, headers[12], results.getSpStartPosition()[i][1]);
 			SharedTable.add(label, headers[13], results.getSpStartPosition()[i][2]);
 		}
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 	}
 
 	private void showSkeleton(final Skeletonize3D_ skeletoniser,

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -201,9 +201,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 			ellipsoids.add(ellipsoid);
 		}
 		addResults(subspaces, ellipsoids);
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -80,15 +80,12 @@ import org.joml.Quaterniond;
 import org.joml.Quaterniondc;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
-import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.DialogPrompt.Result;
 import org.scijava.ui.UIService;
 import org.scijava.widget.NumberWidget;
@@ -173,14 +170,6 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 			required = false)
 	private boolean displayMILVectors;
 
-	/**
-	 * The anisotropy results in a {@link Table}.
-	 * <p>
-	 * Null if there are no results.
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
 	@Parameter
 	private LogService logService;
 	@Parameter

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/BoneJCommand.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/BoneJCommand.java
@@ -11,16 +11,30 @@ import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.bonej.wrapperPlugins.wrapperUtils.UsageReporter;
+import org.scijava.ItemIO;
 import org.scijava.command.CommandService;
 import org.scijava.command.ContextCommand;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.PluginService;
 import org.scijava.prefs.PrefService;
+import org.scijava.table.DefaultColumn;
+import org.scijava.table.Table;
 
 import static java.util.stream.Collectors.toList;
 
 public abstract class BoneJCommand extends ContextCommand {
     private static UsageReporter reporter;
     protected List<Subspace<BitType>> subspaces;
+
+
+    /**
+     * The results of the command in a {@link Table}.
+     * <p>
+     * Null if there are no results.
+     * </p>
+     */
+    @Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
+    protected Table<DefaultColumn<Double>, Double> resultsTable;
 
     protected <C extends ComplexType<C>> List<Subspace<BitType>> find3DSubspaces(
             final ImgPlus<C> image) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -102,9 +102,7 @@ public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends 
 			final String label = suffix.isEmpty() ? name : name + " " + suffix;
 			subspaceConnectivity(label, subspace.interval);
 		});
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -47,13 +47,10 @@ import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 
 /**
@@ -70,16 +67,6 @@ public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends 
 
 	@Parameter(validater = "validateImage")
 	private ImgPlus<T> inputImage;
-
-	/**
-	 * The connectivity results in a {@link Table}
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
-
 	@Parameter
 	private OpService opService;
 	@Parameter

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -47,13 +47,10 @@ import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -74,16 +71,6 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 
 	@Parameter(validater = "validateImage")
 	private ImgPlus<T> inputImage;
-
-	/**
-	 * The element faction results in a {@link Table}
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
-
 	@Parameter
 	private OpService opService;
 	@Parameter

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -110,9 +110,7 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 			final String label = suffix.isEmpty() ? name : name + " " + suffix;
 			addResults(label, foregroundSize, totalSize, ratio);
 		}
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -92,8 +92,6 @@ import org.scijava.command.Command;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 
 import sc.fiji.skeletonize3D.Skeletonize3D_;
@@ -185,12 +183,6 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	private List<ImgPlus> ellipsoidFactorOutputImages;
 	@Parameter(label = "Seed Points", type = ItemIO.OUTPUT)
 	private ImgPlus<ByteType> seedPointImage;// 0=not a seed, 1=medial seed
-
-	/**
-	 * The EF results in a {@link Table}, null if there are no results
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	private ImgPlus<BitType> inputAsBitType;
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -232,6 +232,10 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			counter++;
 			totalEllipsoids += ellipsoids.size();
 		}
+		if (totalEllipsoids == 0) {
+			cancelMacroSafe(this, NO_ELLIPSOIDS_FOUND);
+			return;
+		}
 
 		if(runs>1)
 		{
@@ -555,11 +559,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		final String label = inputImage.getName();
 		SharedTable.add(label, "filling percentage", fillingPercentage);
 		SharedTable.add(label, "number of ellipsoids found in total", totalEllipsoids);
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		} else {
-			cancelMacroSafe(this, NO_ELLIPSOIDS_FOUND);
-		}
+		resultsTable = SharedTable.getTable();
 	}
 
 	@SuppressWarnings("unused")

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -51,13 +51,10 @@ import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
 import org.joml.Matrix4dc;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
-import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 
 /**
@@ -80,16 +77,6 @@ public class FitEllipsoidWrapper extends BoneJCommand {
 	// there's no stable ROI system for ImageJ2 classes yet.
 	@Parameter(validater = "validateImage")
 	private ImagePlus inputImage;
-
-	/**
-	 * The ellipsoid results in a {@link Table}.
-	 * <p>
-	 * Null if there are no results.
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
-
 	@Parameter
 	private OpService opService;
 	@Parameter

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -107,9 +107,7 @@ public class FitEllipsoidWrapper extends BoneJCommand {
 			return;
 		}
 		addResults(result.get());
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -169,9 +169,7 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 			statusService.showProgress(3, 3);
 		});
 		fillResultsTable(subspaces, dimensions, rSquared);
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -60,11 +60,9 @@ import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.GenericTable;
-import org.scijava.table.Table;
 import org.scijava.widget.NumberWidget;
 
 /**
@@ -126,15 +124,6 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 	@Parameter(label = "Show points",
 		description = "Show (log(size), -log(count)) points", required = false)
 	private boolean showPoints;
-
-	/**
-	 * The fractal dimension and R² values for each 3D subspace in a table
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	/**
 	 * Tables containing the (-log(size), log(count)) points for each 3D subspace

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -182,6 +182,9 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		statusService.showProgress(3, PROGRESS_STEPS);
 		final Map<Integer, List<Vertex>> valenceMap = VertexUtils.groupByValence(
 			cleanGraph.getVertices(), minimumValence, maximumValence);
+		if (valenceMap.isEmpty()) {
+			cancelMacroSafe(this, NO_RESULTS_MSG);
+		}
 		statusService.showStatus("Intertrabecular angles: calculating angles");
 		statusService.showProgress(4, PROGRESS_STEPS);
 		final Map<Integer, DoubleStream> radianMap = createRadianMap(valenceMap);
@@ -197,12 +200,7 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 			final String heading = valence.toString();
 			angles.forEach(angle -> SharedTable.add(label, heading, angle));
 		});
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
-		else {
-			cancelMacroSafe(this, NO_RESULTS_MSG);
-		}
+		resultsTable = SharedTable.getTable();
 	}
 
 	private Graph[] analyzeSkeleton(final ImagePlus skeleton) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -58,7 +58,6 @@ import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.Table;
 import org.scijava.ui.UIService;
@@ -141,9 +140,6 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		description = "Print the percentage of each of the type of edges that were culled after calling analyseSkeleton",
 		required = false, persistKey = "ITA_print_culled_edges")
 	private boolean printCulledEdgePercentages;
-	/** The ITA angles in a {@link Table}, null if there are no results */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> anglesTable;
 	/**
 	 * The ITA edge-end coordinates in a {@link Table}, null if there are no
 	 * results
@@ -202,7 +198,7 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 			angles.forEach(angle -> SharedTable.add(label, heading, angle));
 		});
 		if (SharedTable.hasData()) {
-			anglesTable = SharedTable.getTable();
+			resultsTable = SharedTable.getTable();
 		}
 		else {
 			cancelMacroSafe(this, NO_RESULTS_MSG);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -127,9 +127,7 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 			saveMeshes(meshes);
 		}
 		calculateAreas(meshes);
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -64,14 +64,11 @@ import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 import org.scijava.util.StringUtils;
 import org.scijava.widget.FileWidget;
@@ -94,21 +91,10 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 
 	@Parameter(validater = "validateImage")
 	private ImgPlus<T> inputImage;
-
-	/**
-	 * The surface area results in a {@link Table}
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
-
 	@Parameter(label = "Export STL file(s)",
 		description = "Create a binary STL file from the surface mesh",
 		required = false)
 	private boolean exportSTL;
-
 	@Parameter
 	private OpService opService;
 	@Parameter

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -51,13 +51,10 @@ import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
-import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 
 /**
  * First this command creates a surface mesh from both all foreground voxels
@@ -80,23 +77,12 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 
 	@Parameter(validater = "validateImage")
 	private ImgPlus<T> inputImage;
-
-	/**
-	 * The surface faction results in a {@link Table}
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
-
 	@Parameter
 	private OpService opService;
 	@Parameter
 	private UnitService unitService;
 	@Parameter
 	private StatusService statusService;
-
 	/** Header of the thresholded volume column in the results table */
 	private String bVHeader;
 	/** Header of the total volume column in the results table */

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -100,9 +100,7 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 			calculateSubspaceVolumes(subspaces.get(i), i + 1);
 			statusService.showProgress(i, subspaces.size());
 		}
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -115,9 +115,7 @@ public class ThicknessWrapper extends BoneJCommand {
 			addMapResults(map);
 			thicknessMaps.put(foreground, map);
 		});
-		if (SharedTable.hasData()) {
-			resultsTable = SharedTable.getTable();
-		}
+		resultsTable = SharedTable.getTable();
 		if (showMaps) {
 			final LUT fire = Common.makeFire();
 			trabecularMap = thicknessMaps.get(true);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -51,8 +51,6 @@ import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.table.DefaultColumn;
-import org.scijava.table.Table;
 import org.scijava.ui.UIService;
 import org.scijava.widget.ChoiceWidget;
 
@@ -94,15 +92,6 @@ public class ThicknessWrapper extends BoneJCommand {
 
 	@Parameter(label = "Trabecular spacing", type = ItemIO.OUTPUT)
 	private ImagePlus spacingMap;
-
-	/**
-	 * The calculated thickness statistics in a {@link Table}
-	 * <p>
-	 * Null if there are no results
-	 * </p>
-	 */
-	@Parameter(type = ItemIO.OUTPUT, label = "BoneJ results")
-	private Table<DefaultColumn<Double>, Double> resultsTable;
 
 	@Parameter
 	private UIService uiService;

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -87,7 +87,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		// VERIFY
 		@SuppressWarnings("unchecked")
 		final List<DefaultColumn<Double>> table =
-			(List<DefaultColumn<Double>>) module.getOutput("anglesTable");
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
 		assertEquals(2, table.size());
 		final DefaultColumn<Double> threeColumn = table.get(0);
@@ -149,7 +149,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		// VERIFY
 		@SuppressWarnings("unchecked")
 		final List<DefaultColumn<Double>> table =
-			(List<DefaultColumn<Double>>) module.getOutput("anglesTable");
+			(List<DefaultColumn<Double>>) module.getOutput("resultsTable");
 		assertNotNull(table);
 		assertEquals(1, table.size());
 		final DefaultColumn<Double> fiveColumn = table.get(0);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -183,7 +183,7 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 	 * (or skeletonisation didn't change it)
 	 */
 	@Test
-	public void testNoImageWhenNoSkeletonisation() throws Exception {
+	public void testNoImageShownWhenSkeletonProducesEmptyGraph() throws Exception {
 		// SETUP
 		doNothing().when(MOCK_UI).show(any(ImagePlus.class));
 		final ImagePlus pixel = NewImage.createByteImage("Test", 3, 3, 1,
@@ -191,13 +191,10 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 		pixel.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
 
 		// EXECUTE
-		final CommandModule module = command().run(
-			IntertrabecularAngleWrapper.class, true, "inputImage", pixel).get();
+		command().run(IntertrabecularAngleWrapper.class, true, "inputImage", pixel, "minimumValence",
+						3).get();
 
 		// VERIFY
-		assertEquals(
-			"Sanity check failed: plugin cancelled before image could have been shown",
-			NO_RESULTS_MSG, module.getCancelReason());
 		verify(MOCK_UI, after(250).never()).show(any(ImagePlus.class));
 	}
 


### PR DESCRIPTION
Contrary to what I claimed in #245 it's possible to move the results table to the base class. The failing tests mentioned failed because one of our commands didn't call its results table `resultsTable`.