### PR TITLE
Explicity create and protect the background particle identity

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -168,7 +168,7 @@ public class ConnectedComponents {
 	private static int[][] generateLut(ArrayList<MutableList<IntHashSet>> chunkMaps, int[] chunkIDOffsets) {
 		// merge labels between the HashSets, handling the chunk offsets and indexes
 		bucketFountain(chunkMaps, chunkIDOffsets);
-
+		
 		HashMap<Integer, Integer> lutMap = makeLutMap(chunkMaps);
 
 		return lutFromLutMap(lutMap, chunkMaps, chunkIDOffsets);
@@ -240,8 +240,12 @@ public class ConnectedComponents {
 				// label image IDs have the chunk ID offset
 				int ID = IDoffset;
 
-				if (ID == 0)
+				if (ID == 0) {
+					//set up the background ID = 0
+					chunkMap.add(new IntHashSet(1));
+					chunkMap.get(0).add(0);
 					ID = 1;
+				}
 
 				final int startSlice = startSlices[chunk];
 
@@ -388,8 +392,12 @@ public class ConnectedComponents {
 					}
 				}
 				// there is always one too many IDs per chunk, so trim the last one off
-				if (chunkMap.size() > 0)
-					chunkMap.remove(chunkMap.size() - 1);
+				// unless the map is empty
+				if (chunkMap.size() > 0 ) {
+					//don't remove the background element
+					if (ID == 1 && chunkMap.size() == 1) {}
+					else chunkMap.remove(chunkMap.size() - 1);
+				}
 			});
 		}
 		Multithreader.startAndJoin(threads);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -388,7 +388,8 @@ public class ConnectedComponents {
 					}
 				}
 				// there is always one too many IDs per chunk, so trim the last one off
-				chunkMap.remove(chunkMap.size() - 1);
+				if (chunkMap.size() > 0)
+					chunkMap.remove(chunkMap.size() - 1);
 			});
 		}
 		Multithreader.startAndJoin(threads);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
@@ -307,8 +307,10 @@ public class ParticleAnalysis {
 		this.particleSizes = new long[nParticles];
 		for (int i = 0; i < nParticles; i++) {
 			long partSum = 0;
-			for (int z = 0; z < d; z++)
-				partSum += partSizes[z][i];
+			for (int z = 0; z < d; z++) {
+				if (partSizes[z] != null)
+					partSum += partSizes[z][i];
+			}
 			this.particleSizes[i] = partSum;
 		}
 		return this.particleSizes.clone();

--- a/Legacy/bonej/src/test/java/org/bonej/plugins/ConnectedComponentsTest.java
+++ b/Legacy/bonej/src/test/java/org/bonej/plugins/ConnectedComponentsTest.java
@@ -1,0 +1,66 @@
+package org.bonej.plugins;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.ByteProcessor;
+import ij.process.ImageProcessor;
+
+public class ConnectedComponentsTest {
+
+	/**
+	 * Check that the correct number of particles is returned regardless of
+	 * position of the particle. One particle (ID = 0) is background
+	 * and we draw one particle so the correct number of particles is two.
+	 */
+	@Test
+	public void testGetNParticles() {
+		for (int z = 1; z <= 57; z += 8) {
+			for (int y = 0; y < 56; y += 8) {
+				for (int x = 0; x < 56; x += 8) {
+					final ImagePlus imp = brick(64, 64, 64, 8, 8, 8, x, y, z);
+					ConnectedComponents cc = new ConnectedComponents();
+					cc.run(imp, ConnectedComponents.FORE);
+					assertEquals(2, cc.getNParticles());			
+				}
+			}
+		}
+	}
+
+	/**
+	 * 
+	 * @param width image width
+	 * @param height image height
+	 * @param depth image depth
+	 * @param brickWidth brick width
+	 * @param brickHeight brick height
+	 * @param brickDepth brick depth
+	 * @param x top left corner x coordinate
+	 * @param y top left corner y coordinate
+	 * @param z top left corner z coordinate
+	 * @return Image stack containing 0 background and a cuboid of foreground
+	 */
+	private static ImagePlus brick(final int width, final int height, final int depth,
+			final int brickWidth, final int brickHeight, final int brickDepth,
+			final int x, final int y, final int z) {
+		final ImageStack stack = new ImageStack(width, height);
+		
+		for (int i = 0; i < depth; i++) {
+			final ByteProcessor bp = new ByteProcessor(width, height);
+			stack.addSlice(bp);
+		}
+		
+		for (int i = z; i < z + brickDepth; i++) {
+			final ImageProcessor ip = stack.getProcessor(z);
+			ip.setColor(255);
+			ip.setRoi(x, y, brickWidth, brickHeight);
+			ip.fill();
+			stack.setProcessor(ip, z);
+		}
+		final ImagePlus imp = new ImagePlus("brick", stack);
+		return imp;
+	}
+}


### PR DESCRIPTION
This PR fixes #261, which resulted from an implicit creation of the background particle ID (0) that was either not created, or created and then destroyed when there was no foreground particle in the zeroth image processing chunk.