### PR TITLE
Improvements to EF user experience, bug fixes to Particle Analyser & Slice Geometry

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -117,7 +117,6 @@ public class ConnectedComponents {
 		final int nChunks = nSlices < minSlicesPerChunk * nProcessors
 				? (int) Math.ceil((double) nSlices / (double) minSlicesPerChunk)
 				: nProcessors;
-
 		// set up chunk sizes - last chunk is the remainder
 		final int slicesPerChunk = (int) Math.ceil((double) nSlices / (double) nChunks);
 
@@ -136,9 +135,10 @@ public class ConnectedComponents {
 
 		// set up a map split into one per chunk
 		final ArrayList<MutableList<IntHashSet>> chunkMaps = new ArrayList<>(nChunks);
+		// assume there is a new particle label for every 10000 pixels
+		final int initialArrayCapacity = 1 + (int)((long) w * (long) h * slicesPerChunk / 10000);
+		
 		for (int chunk = 0; chunk < nChunks; chunk++) {
-			// assume there is a new particle label for every 10000 pixels
-			final int initialArrayCapacity = 1 + w * h * slicesPerChunk / 10000;
 			final MutableList<IntHashSet> map = FastList.newList(initialArrayCapacity);
 			chunkMaps.add(map);
 		}

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
@@ -128,11 +128,11 @@ public class SliceGeometry implements PlugIn, DialogListener {
 	/**
 	 * 2nd moment of area around minimum principal axis (shorter axis, larger I)
 	 */
-	private double[] Imax;
+	private double[] Imin;
 	/**
 	 * 2nd moment of area around maximum principal axis (longer axis, smaller I)
 	 */
-	private double[] Imin;
+	private double[] Imax;
 	/** product moment of area, should be 0 if theta calculated perfectly */
 	private double[] Ipm;
 	/** length of major axis */
@@ -144,9 +144,9 @@ public class SliceGeometry implements PlugIn, DialogListener {
 	/** maximum distance from maximum principal axis (shorter) */
 	private double[] maxRadMax;
 	/** Section modulus around minimum principal axis */
-	private double[] Zmax;
-	/** Section modulus around maximum principal axis */
 	private double[] Zmin;
+	/** Section modulus around maximum principal axis */
+	private double[] Zmax;
 	/** Maximum diameter */
 	private double[] feretMax;
 	/** Angle of maximum diameter */
@@ -355,8 +355,8 @@ public class SliceGeometry implements PlugIn, DialogListener {
 			rt.addValue("Imin (" + units + "^4)", Imin[s]);
 			rt.addValue("Imax (" + units + "^4)", Imax[s]);
 			rt.addValue("Ipm (" + units + "^4)", Ipm[s]);
-			rt.addValue("Zmax (" + units + "³)", Zmax[s]);
 			rt.addValue("Zmin (" + units + "³)", Zmin[s]);
+			rt.addValue("Zmax (" + units + "³)", Zmax[s]);
 			rt.addValue("Zpol (" + units + "³)", Zpol[s]);
 			rt.addValue("Feret Min (" + units + ")", feretMin[s]);
 			rt.addValue("Feret Max (" + units + ")", feretMax[s]);
@@ -598,15 +598,15 @@ public class SliceGeometry implements PlugIn, DialogListener {
 		}
 		// Get I and Z around the principal axes
 		final double[][] result = calculateAngleMoments(imp, min, max, theta);
-		Imax = result[0];
-		Imin = result[1];
+		Imin = result[0];
+		Imax = result[1];
 		Ipm = result[2];
 		R1 = result[3];
 		R2 = result[4];
 		maxRadMin = result[5];
 		maxRadMax = result[6];
-		Zmax = result[7];
-		Zmin = result[8];
+		Zmin = result[7];
+		Zmax = result[8];
 		Zpol = result[9];
 
 		// optionally get I and Z around some user-defined axes

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
@@ -68,6 +68,9 @@ public class EllipsoidFactorOutputGenerator extends
     @Parameter(required = false)
     boolean showSecondaryImages = false;
 
+    @Parameter(required = false)
+    String inputName = "";
+
     private List<ImgPlus> eFOutputs;
 
     @Override
@@ -171,12 +174,12 @@ public class EllipsoidFactorOutputGenerator extends
             eFOutputs.add(createIDImage(idImage, ellipsoids));
 
             //add to output list
-            eFOutputs.add(createRadiusImage(as, idImage, "a"));
-            eFOutputs.add(createRadiusImage(bs, idImage, "b"));
-            eFOutputs.add(createRadiusImage(cs, idImage, "c"));
+            eFOutputs.add(createRadiusImage(as, idImage, inputName+"_a"));
+            eFOutputs.add(createRadiusImage(bs, idImage, inputName+"_b"));
+            eFOutputs.add(createRadiusImage(cs, idImage, inputName+"_c"));
 
-            eFOutputs.add(createAxisRatioImage(aBRatios, idImage, "a/b"));
-            eFOutputs.add(createAxisRatioImage(bCRatios, idImage, "b/c"));
+            eFOutputs.add(createAxisRatioImage(aBRatios, idImage, inputName+"_a/b"));
+            eFOutputs.add(createAxisRatioImage(bCRatios, idImage, inputName+"_b/c"));
         }
     }
 
@@ -194,7 +197,7 @@ public class EllipsoidFactorOutputGenerator extends
             final int integer = cursor.get().getInteger();
             cursor1.get().set(integer);
         }
-        ImgPlus eIdImage = new ImgPlus<>(ints,"ID");
+        ImgPlus eIdImage = new ImgPlus<>(ints,inputName+"_ID");
         eIdImage.setChannelMaximum(0, ellipsoids.size() / 10.0f);
         eIdImage.setChannelMinimum(0, -1.0f);
         return eIdImage;
@@ -206,7 +209,7 @@ public class EllipsoidFactorOutputGenerator extends
         final double[] ellipsoidFactors = ellipsoids.parallelStream()
                 .mapToDouble(EllipsoidFactorOutputGenerator::computeWeightedEllipsoidFactor).toArray();
         mapValuesToImage(ellipsoidFactors, idImage, ellipsoidFactorImage);
-        final ImgPlus<FloatType> efImage = new ImgPlus<>(ellipsoidFactorImage, "EF");
+        final ImgPlus<FloatType> efImage = new ImgPlus<>(ellipsoidFactorImage, inputName+"_EF");
         efImage.setChannelMaximum(0,1);
         efImage.setChannelMinimum(0, -1);
         efImage.initializeColorTables(1);
@@ -238,7 +241,7 @@ public class EllipsoidFactorOutputGenerator extends
         final Img<FloatType> volumeImage = createNaNImg(idImage);
         final double[] volumes = ellipsoids.parallelStream().mapToDouble(QuickEllipsoid::getVolume).toArray();
         mapValuesToImage(volumes, idImage, volumeImage);
-        ImgPlus vImage = new ImgPlus(volumeImage,"Volume");
+        ImgPlus vImage = new ImgPlus(volumeImage,inputName+"_volume");
         vImage.setChannelMaximum(0, ellipsoids.get(0).getVolume());
         vImage.setChannelMinimum(0, -1.0f);
         return vImage;
@@ -266,7 +269,7 @@ public class EllipsoidFactorOutputGenerator extends
             flinnPeakPlotRA.get().set(currentValue + 1.0f);
         }
 
-        ImgPlus flinnPeakPlotImage = new ImgPlus<>(flinnPeakPlot, "Flinn Peak Plot");
+        ImgPlus flinnPeakPlotImage = new ImgPlus<>(flinnPeakPlot, inputName+"_Flinn_peak_plot");
 
         flinnPeakPlotImage.setChannelMaximum(0, 255.0f);
         flinnPeakPlotImage.setChannelMinimum(0, 0.0f);
@@ -292,7 +295,7 @@ public class EllipsoidFactorOutputGenerator extends
             flinnRA.setPosition(y, 1);
             flinnRA.get().setOne();
         }
-        ImgPlus flinnPlotImage = new ImgPlus<>(flinnPlot, "Unweighted Flinn Plot");
+        ImgPlus flinnPlotImage = new ImgPlus<>(flinnPlot, inputName+"_unweighted_Flinn_plot");
         flinnPlotImage.setChannelMaximum(0, 255.0f);
         flinnPlotImage.setChannelMinimum(0, 0.0f);
 

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
@@ -276,10 +276,10 @@ public class EllipsoidFactorOutputGenerator extends
         flinnPeakPlotImage.setChannelMaximum(0, 255.0f);
         flinnPeakPlotImage.setChannelMinimum(0, 0.0f);
         DefaultLinearAxis xFlinnAxis = new DefaultLinearAxis(Axes.get("b/c",true),1.0/FLINN_PLOT_DIMENSION);
-        xFlinnAxis.setUnit("");
+        xFlinnAxis.setUnit("b/c");
         DefaultLinearAxis yFlinnAxis = new DefaultLinearAxis(Axes.get("a/b",true),-1.0/FLINN_PLOT_DIMENSION);
         yFlinnAxis.setOrigin(FLINN_PLOT_DIMENSION);
-        yFlinnAxis.setUnit("");
+        yFlinnAxis.setUnit("a/b");
 
         flinnPeakPlotImage.setAxis(xFlinnAxis,0);
         flinnPeakPlotImage.setAxis(yFlinnAxis,1);
@@ -304,10 +304,10 @@ public class EllipsoidFactorOutputGenerator extends
         flinnPlotImage.setChannelMaximum(0, 255.0f);
         flinnPlotImage.setChannelMinimum(0, 0.0f);
         DefaultLinearAxis xFlinnAxis = new DefaultLinearAxis(Axes.get("b/c",true),1.0/FLINN_PLOT_DIMENSION);
-        xFlinnAxis.setUnit("");
+        xFlinnAxis.setUnit("b/c");
         DefaultLinearAxis yFlinnAxis = new DefaultLinearAxis(Axes.get("a/b",true),-1.0/FLINN_PLOT_DIMENSION);
         yFlinnAxis.setOrigin(FLINN_PLOT_DIMENSION);
-        yFlinnAxis.setUnit("");
+        yFlinnAxis.setUnit("a/b");
 
         flinnPlotImage.setAxis(xFlinnAxis,0);
         flinnPlotImage.setAxis(yFlinnAxis,1);

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
@@ -60,7 +60,7 @@ public class EllipsoidFactorOutputGenerator extends
         AbstractBinaryFunctionOp<IterableInterval<IntType>, List<QuickEllipsoid>, List<ImgPlus>>{
     // Several ellipsoids may fall in same bin if this is too small a number!
     // This will be ignored!
-    private static final long FLINN_PLOT_DIMENSION = 501;
+    private static final long FLINN_PLOT_DIMENSION = 512;
 
     @Parameter(required = false)
     boolean showFlinnPlots = false;
@@ -255,6 +255,7 @@ public class EllipsoidFactorOutputGenerator extends
         final RandomAccess<FloatType> flinnPeakPlotRA = flinnPeakPlot.randomAccess();
         final Cursor<IntType> idCursor = ellipsoidIDs.localizingCursor();
         final long[] position = new long[4];
+        float maxPixelCount = 0;
         while (idCursor.hasNext()) {
             idCursor.fwd();
             if (idCursor.get().getInteger() < 0) {
@@ -268,12 +269,15 @@ public class EllipsoidFactorOutputGenerator extends
             final long y = Math.round(aBRatios[localMaxEllipsoidID] * (FLINN_PLOT_DIMENSION - 1));
             flinnPeakPlotRA.setPosition(new long[]{x, FLINN_PLOT_DIMENSION - y - 1});
             final float currentValue = flinnPeakPlotRA.get().getRealFloat();
-            flinnPeakPlotRA.get().set(currentValue + 1.0f);
+            final float newValue = currentValue + 1.0f;
+            flinnPeakPlotRA.get().set(newValue);
+            if (newValue > maxPixelCount)
+            	maxPixelCount = newValue;
         }
 
         ImgPlus flinnPeakPlotImage = new ImgPlus<>(flinnPeakPlot, inputName+"_Flinn_peak_plot");
 
-        flinnPeakPlotImage.setChannelMaximum(0, 255.0f);
+        flinnPeakPlotImage.setChannelMaximum(0, maxPixelCount);
         flinnPeakPlotImage.setChannelMinimum(0, 0.0f);
         DefaultLinearAxis xFlinnAxis = new DefaultLinearAxis(Axes.get("b/c",true),1.0/FLINN_PLOT_DIMENSION);
         xFlinnAxis.setUnit("b/c");

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGenerator.java
@@ -78,6 +78,8 @@ public class EllipsoidFactorOutputGenerator extends
         eFOutputs = new ArrayList<>();
         calculatePrimaryOutputs(idImage, ellipsoids);
 
+        //volume image must always be calculated
+        eFOutputs.add(createVolumeImage(ellipsoids, idImage));
         if(showFlinnPlots || showSecondaryImages)
         {
             calculateSecondaryOutputs(idImage, ellipsoids);
@@ -88,16 +90,9 @@ public class EllipsoidFactorOutputGenerator extends
             postProcessWeightedAveraging(idImage);
         }
 
-
-        //divide EF-image by volume image
-        //volume image added to verbose outputs only if needed, but must always be calculated
-        ImgPlus volumeImage = createVolumeImage(ellipsoids, idImage);
-        if(showSecondaryImages)
-        {
-            eFOutputs.add(volumeImage);
-        }
+        //divide EF-image by volume image (which now contains sum of volumes for each ID)
         final Cursor<? extends RealType> eFCursor = eFOutputs.get(0).cursor();
-        final Cursor<? extends RealType> vCursor = volumeImage.cursor();
+        final Cursor<? extends RealType> vCursor = eFOutputs.get(1).cursor();
         while(eFCursor.hasNext())
         {
             eFCursor.fwd();
@@ -105,6 +100,13 @@ public class EllipsoidFactorOutputGenerator extends
 
             eFCursor.get().setReal(eFCursor.get().getRealDouble()/vCursor.get().getRealDouble());
         }
+
+        //remove volume image if we don't want it
+        if(!showSecondaryImages)
+        {
+            eFOutputs.remove(1);
+        }
+
         return eFOutputs;
     }
 

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategy.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategy.java
@@ -65,7 +65,7 @@ public class EllipsoidOptimisationStrategy extends AbstractBinaryFunctionOp<byte
 	@Parameter
 	private static EllipsoidConstrainStrategy constrainStrategy;
 	@Parameter(required = false)
-	private OptimisationParameters algorithmParameters = new OptimisationParameters(0.435,100,1,100,1.73, 1.0);
+	private OptimisationParameters algorithmParameters = new OptimisationParameters(0.435,100,1,100,1.73);
 	double stackVolume;
 
 
@@ -556,12 +556,6 @@ public class EllipsoidOptimisationStrategy extends AbstractBinaryFunctionOp<byte
 		if (totalIterations == absoluteMaxIterations) {
 			logService.debug("Ellipsoid at (" + centre[0] + ", " + centre[1] + ", " + centre[2]
 					+ ") seems to be out of control, nullifying after " + totalIterations + " iterations");
-			return null;
-		}
-
-		if (ellipsoid.getSortedRadii()[2]<algorithmParameters.minimumSemiAxis) {
-			logService.debug("Ellipsoid at (" + centre[0] + ", " + centre[1] + ", " + centre[2]
-					+ ") is too small, nullifying after " + totalIterations + " iterations");
 			return null;
 		}
 

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/OptimisationParameters.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/OptimisationParameters.java
@@ -39,14 +39,12 @@ public class OptimisationParameters {
     public final int contactSensitivity;
     public final int maxIterations;
     public final double maxDrift;
-    public final double minimumSemiAxis;
 
-    public OptimisationParameters(double inc, int n, int cs, int maxIt, double maxDr, double minSemiAxis){
+    public OptimisationParameters(double inc, int n, int cs, int maxIt, double maxDr){
         vectorIncrement = inc;
         nVectors = n;
         contactSensitivity = cs;
         maxIterations = maxIt;
         maxDrift = maxDr;
-        minimumSemiAxis = minSemiAxis;
     }
 }

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGeneratorTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/EllipsoidFactorOutputGeneratorTest.java
@@ -74,11 +74,11 @@ public class EllipsoidFactorOutputGeneratorTest extends AbstractOpTest {
         final List<QuickEllipsoid> ellipsoids = getEllipsoids();
 
         //EXECUTE
-        final List<ImgPlus> primaryEfOutputs = (List<ImgPlus>) ops.run(EllipsoidFactorOutputGenerator.class,idImage,ellipsoids,false);
-        final List<ImgPlus> allEfOutputs = (List<ImgPlus>) ops.run(EllipsoidFactorOutputGenerator.class,idImage,ellipsoids,true);
+        final List<ImgPlus> primaryEfOutputs = (List<ImgPlus>) ops.run(EllipsoidFactorOutputGenerator.class,idImage,ellipsoids,false,false,"test_image");
+        final List<ImgPlus> allEfOutputs = (List<ImgPlus>) ops.run(EllipsoidFactorOutputGenerator.class,idImage,ellipsoids,true,true,"test_image");
 
         //VERIFY
-        assertEquals("Wrong number of primary outputs", 3,primaryEfOutputs.size());
+        assertEquals("Wrong number of primary outputs", 1,primaryEfOutputs.size());
         assertEquals("Wrong overall number of outputs", 10,allEfOutputs.size());
         allEfOutputs.forEach(out -> assertNotNull("No null outputs expected.", out));
     }

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategyTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategyTest.java
@@ -45,26 +45,6 @@ import net.imagej.ops.AbstractOpTest;
 public class EllipsoidOptimisationStrategyTest extends AbstractOpTest {
 
 	@Test
-	public void testMinimumSemiAxisFilter() {
-		final byte[][] sphere = getSphere(10);
-		final QuickEllipsoid ellipsoidNull = (QuickEllipsoid) ops.run(EllipsoidOptimisationStrategy.class, sphere,
-				new Vector3d(20.5, 20.5, 20.5), new double[]{40, 40, 40},
-				new NoEllipsoidConstrain(), new OptimisationParameters(0.435,100,1,100,1.73, 15));
-
-		final QuickEllipsoid ellipsoidTooBigToBeFiltered = (QuickEllipsoid) ops.run(EllipsoidOptimisationStrategy.class, sphere,
-				new Vector3d(20.5, 20.5, 20.5), new double[]{40, 40, 40},
-				new NoEllipsoidConstrain(), new OptimisationParameters(0.435,100,1,100,1.73, 9.5));
-
-		final QuickEllipsoid ellipsoidZeroFilter = (QuickEllipsoid) ops.run(EllipsoidOptimisationStrategy.class, sphere,
-				new Vector3d(20.5, 20.5, 20.5), new double[]{40, 40, 40},
-				new NoEllipsoidConstrain(), new OptimisationParameters(0.435,100,1,100,1.73, 0));
-
-		assertNull(ellipsoidNull);
-		assertNotNull(ellipsoidTooBigToBeFiltered);
-		assertNotNull(ellipsoidZeroFilter);
-	}
-
-	@Test
 	public void testSkeletonPointOptimisationStrategy() {
 		final byte[][] sphere = getSphere(10);
 		final QuickEllipsoid ellipsoid = (QuickEllipsoid) ops.run(EllipsoidOptimisationStrategy.class, sphere,
@@ -274,7 +254,7 @@ public class EllipsoidOptimisationStrategyTest extends AbstractOpTest {
 
 		final EllipsoidOptimisationStrategy optimisation = (EllipsoidOptimisationStrategy) Functions.binary(ops, EllipsoidOptimisationStrategy.class, QuickEllipsoid.class,
 				new byte[10][10],
-				new Vector3d(),new long[]{10,10,1},  new NoEllipsoidConstrain(), new OptimisationParameters(2,0,0,0,0,1000));
+				new Vector3d(),new long[]{10,10,1},  new NoEllipsoidConstrain(), new OptimisationParameters(2,0,0,0,0));
 
 		//EXECUTE
 		boolean tooSmallInvalid = optimisation.isInvalid(tooSmall, 100,100,100);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -120,17 +120,11 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 		persist = false)
 	private ImagePlus inputImage;
 
-	@Parameter(visibility = ItemVisibility.MESSAGE, columns = 1, persist = false)
-	private String loopSection = "-- LOOPS --";
-
 	@Parameter(label = "Cycle pruning method",
 		description = "Which method is used to prune cycles in the skeleton graph",
 		required = false, style = ChoiceWidget.LIST_BOX_STYLE, choices = { "None",
 			"Shortest branch", "Lowest intensity voxel", "Lowest intensity branch" })
 	private String pruneCycleMethod = "None";
-
-	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false)
-	private String endPointSection = "-- END-POINTS --";
 
 	@Parameter(label = "Prune ends",
 		description = "Prune very short edges with no slabs", required = false)
@@ -140,9 +134,6 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 		description = "Exclude the current selection from pruning",
 		required = false, visibility = ItemVisibility.INVISIBLE, persist = false)
 	private boolean excludeRoi;
-
-	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false)
-	private String resultSection = "-- RESULTS AND OUTPUT --";
 
 	@Parameter(label = "Calculate largest shortest paths",
 		description = "Calculate and display the largest shortest skeleton paths",

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -247,7 +247,7 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 		final String suffix = subspace.toString();
 		final String label = suffix.isEmpty() ? imageName : imageName + " " +
 			suffix;
-		SharedTable.add(label, "Degree of anisotropy", anisotropy);
+		SharedTable.add(label, "DA", anisotropy);
 		if (printRadii) {
 			SharedTable.add(label, "Radius a", ellipsoid.getA());
 			SharedTable.add(label, "Radius b", ellipsoid.getB());

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -178,8 +178,6 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 		persist = false, required = false, callback = "applyMinimum")
 	private boolean recommendedMin;
 	
-	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false)
-	private String instruction = "NB parameter values can affect results significantly";
 	private boolean calibrationWarned;
 	
 	@Parameter(label = "Show radii",

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ConnectivityWrapper.java
@@ -144,9 +144,9 @@ public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends 
 		}
 
 		SharedTable.add(label, "Euler char. (χ)", eulerCharacteristic);
-		SharedTable.add(label, "Corrected Euler (χ + Δχ)", deltaEuler);
+		SharedTable.add(label, "Corr. Euler (χ + Δχ)", deltaEuler);
 		SharedTable.add(label, "Connectivity", connectivity);
-		SharedTable.add(label, "Conn. density " + unitHeader, connectivityDensity);
+		SharedTable.add(label, "Conn.D " + unitHeader, connectivityDensity);
 	}
 
 	private double calculateConnectivityDensity(final RandomAccessibleInterval<?> subspace,
@@ -159,7 +159,7 @@ public class ConnectivityWrapper<T extends RealType<T> & NativeType<T>> extends 
 	}
 
 	private void determineResultUnit() {
-		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, '³');
+		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, "⁻³");
 	}
 
 	// region -- Helper methods --

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ElementFractionWrapper.java
@@ -168,13 +168,12 @@ public class ElementFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 	private void prepareResultDisplay() {
 		final char exponent = ResultUtils.getExponent(inputImage);
 		final String unitHeader = ResultUtils.getUnitHeader(inputImage, unitService,
-			exponent);
+			String.valueOf(exponent));
 		final String sizeDescription = ResultUtils.getSizeDescription(inputImage);
 
-		boneSizeHeader = "Bone " + sizeDescription.toLowerCase() + " " + unitHeader;
-		totalSizeHeader = "Total " + sizeDescription.toLowerCase() + " " +
-			unitHeader;
-		ratioHeader = sizeDescription + " ratio";
+		boneSizeHeader = "B" + sizeDescription + " " + unitHeader;
+		totalSizeHeader = "T" + sizeDescription + " " + unitHeader;
+		ratioHeader = "B" + sizeDescription + "/T" + sizeDescription;
 		elementSize = ElementUtil.calibratedSpatialElementSize(inputImage,
 			unitService);
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -201,7 +201,10 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	@Parameter(label = "Seed points on topology-preserving skeletonization ", description = "Tick this if you would like ellipsoids to be seeded on the topology-preserving skeletonization (\"Skeletonize3D\").")
 	private boolean seedOnTopologyPreserving = false;
 
-	@Parameter(label = "Show secondary images")
+	@Parameter(label = "Show Flinn plots")
+	private boolean showFlinnPlots = false;
+
+	@Parameter(label = "Show verbose output images")
 	private boolean showSecondaryImages = false;
 
 	@Parameter (label = "EF Output Images", type = ItemIO.OUTPUT)
@@ -239,7 +242,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			//add result of this run to overall result
 			//TODO do not match Op every time
 			final List<ImgPlus> currentOutputList = (List<ImgPlus>) opService.run(EllipsoidFactorOutputGenerator.class, ellipsoidIdentityImage,
-					ellipsoids, showSecondaryImages);
+					ellipsoids, showFlinnPlots, showSecondaryImages);
 
 			if(outputList!=null)
 			{
@@ -438,12 +441,15 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			quickEllipsoids.addAll(skeletonSeededEllipsoids);
 		}
 
-		final DefaultLinearAxis xAxis = (DefaultLinearAxis) inputImage.axis(0);
-		final DefaultLinearAxis yAxis = (DefaultLinearAxis) inputImage.axis(1);
-		final DefaultLinearAxis zAxis = (DefaultLinearAxis) inputImage.axis(2);
-		seedPointImage = new ImgPlus<>(seedImage, "Seed points", xAxis, yAxis, zAxis);
-		seedPointImage.setChannelMaximum(0, 1);
-		seedPointImage.setChannelMinimum(0, 0);
+		if(showSecondaryImages)
+		{
+			final DefaultLinearAxis xAxis = (DefaultLinearAxis) inputImage.axis(0);
+			final DefaultLinearAxis yAxis = (DefaultLinearAxis) inputImage.axis(1);
+			final DefaultLinearAxis zAxis = (DefaultLinearAxis) inputImage.axis(2);
+			seedPointImage = new ImgPlus<>(seedImage, "Seed points", xAxis, yAxis, zAxis);
+			seedPointImage.setChannelMaximum(0, 1);
+			seedPointImage.setChannelMinimum(0, 0);
+		}
 		quickEllipsoids.sort((a, b) -> Double.compare(b.getVolume(), a.getVolume()));
 		final long stop = System.currentTimeMillis();
 		logService.info("Found " + quickEllipsoids.size() + " ellipsoids in " + (stop - start) + " ms");

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -204,6 +204,9 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	@Parameter(label = "Show Flinn plots")
 	private boolean showFlinnPlots = false;
 
+	@Parameter(label = "Show algorithm convergence")
+	private boolean showConvergence = false;
+
 	@Parameter(label = "Show verbose output images")
 	private boolean showSecondaryImages = false;
 
@@ -247,15 +250,21 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			if(outputList!=null)
 			{
 				outputList = sumOutput(outputList, currentOutputList, counter);
-				final Map<String, Double> errors = errorTracking.calculate(outputList.get(0));
-				errors.forEach((stat,value) -> logService.info(stat+": "+value.toString()));
-				SharedTable.add(inputImage.getName(),"median change "+i,errors.get("Median"));
-				SharedTable.add(inputImage.getName(),"maximum change "+i,errors.get("Max"));
+				if(showConvergence)
+				{
+					final Map<String, Double> errors = errorTracking.calculate(outputList.get(0));
+					errors.forEach((stat,value) -> logService.info(stat+": "+value.toString()));
+					SharedTable.add(inputImage.getName(),"median change "+i,errors.get("Median"));
+					SharedTable.add(inputImage.getName(),"maximum change "+i,errors.get("Max"));
+				}
 			}
 			else{
 				outputList = currentOutputList;
-				SharedTable.add(inputImage.getName(),"median change "+i,2);
-				SharedTable.add(inputImage.getName(),"maximum change "+i,2);
+				if(showConvergence)
+				{
+					SharedTable.add(inputImage.getName(), "median change " + i, 2);
+					SharedTable.add(inputImage.getName(), "maximum change " + i, 2);
+				}
 			}
 			counter++;
 			totalEllipsoids += ellipsoids.size();
@@ -315,7 +324,11 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		SharedTable.add(inputImage.getName(), "Max EF", max);
 		final double min = stats.getMin();
 		SharedTable.add(inputImage.getName(), "Min EF", min);
-		addResults(totalEllipsoids, fillingPercentage);
+		if(showConvergence)
+		{
+			addResults(totalEllipsoids, fillingPercentage);
+		}
+		resultsTable = SharedTable.getTable();
 		statusService.showStatus("Ellipsoid Factor completed");
 		reportUsage();
 	}
@@ -590,7 +603,6 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		final String label = inputImage.getName();
 		SharedTable.add(label, "filling percentage", fillingPercentage);
 		SharedTable.add(label, "number of ellipsoids found in total", totalEllipsoids);
-		resultsTable = SharedTable.getTable();
 	}
 
 	@SuppressWarnings("unused")

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -114,7 +114,6 @@ import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.scijava.ItemIO;
-import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
@@ -172,8 +171,6 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	private ImgPlus<UnsignedIntType> inputImage;
 
 	//algorithm parameters
-	@Parameter(visibility = ItemVisibility.MESSAGE, persist = false)
-	private String setup = "Setup";
 	@Parameter(label = "Vectors")
 	int nVectors = 100;
 	@Parameter(label = "Sampling increment", description = "Increment for vector searching in real units. Default is ~Nyquist sampling of a unit pixel.", min="0.01", max = "0.99")

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -183,8 +183,6 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	private int maxIterations = 100;
 	@Parameter(label = "Maximum drift", description = "Maximum distance ellipsoid may drift from seed point. Defaults to unit voxel diagonal length", min="0")
 	private double maxDrift = Math.sqrt(3);
-	@Parameter(label = "Minimum semi axis", description = "Minimum length for the longest semi-axis needed for an ellipsoid to be valid. Defaults to unit voxel", min="0")
-	private double minimumSemiAxis = 1.0;
 
 	//averaging / smoothing
 	@Parameter(label = "Repetitions", description = "Number of currentIteration over which to average EF value", min="1")
@@ -414,7 +412,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		final byte[][] pixels = imgPlusToByteArray(imp);
 		final ArrayImg<ByteType, ByteArray> seedImage = ArrayImgs.bytes(w, h, d);
 		final List<QuickEllipsoid> quickEllipsoids = new ArrayList<>();
-		final OptimisationParameters parameters = new OptimisationParameters(vectorIncrement, nVectors, contactSensitivity, maxIterations, maxDrift, minimumSemiAxis);
+		final OptimisationParameters parameters = new OptimisationParameters(vectorIncrement, nVectors, contactSensitivity, maxIterations, maxDrift);
 		if (seedOnDistanceRidge) {
 			final ImgPlus<BitType> inputAsBitType = Common.toBitTypeImgPlus(opService, inputImage);
 			List<Vector3d> ridgePoints = getDistanceRidgePoints(inputAsBitType);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -245,7 +245,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			//add result of this run to overall result
 			//TODO do not match Op every time
 			final List<ImgPlus> currentOutputList = (List<ImgPlus>) opService.run(EllipsoidFactorOutputGenerator.class, ellipsoidIdentityImage,
-					ellipsoids, showFlinnPlots, showSecondaryImages);
+					ellipsoids, showFlinnPlots, showSecondaryImages, inputImage.getName().split("\\.")[0]);
 
 			if(outputList!=null)
 			{
@@ -459,7 +459,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			final DefaultLinearAxis xAxis = (DefaultLinearAxis) inputImage.axis(0);
 			final DefaultLinearAxis yAxis = (DefaultLinearAxis) inputImage.axis(1);
 			final DefaultLinearAxis zAxis = (DefaultLinearAxis) inputImage.axis(2);
-			seedPointImage = new ImgPlus<>(seedImage, "Seed points", xAxis, yAxis, zAxis);
+			seedPointImage = new ImgPlus<>(seedImage, inputImage.getName().split("\\.")[0]+"_seed_points", xAxis, yAxis, zAxis);
 			seedPointImage.setChannelMaximum(0, 1);
 			seedPointImage.setChannelMinimum(0, 0);
 		}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -330,7 +330,7 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		SharedTable.add(inputImage.getName(), "Min EF", min);
 		if(showConvergence)
 		{
-			for(int i=0; i<runs; i++)
+			for(int i=1; i<runs; i++)
 			{
 				SharedTable.add(inputImage.getName(),"median change "+i, medianErrors[i]);
 				SharedTable.add(inputImage.getName(),"maximum change "+i, maxErrors[i]);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -226,6 +226,9 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 				new EllipsoidFactorErrorTracking(opService);
 
 		int counter = 0;
+		double[] medianErrors = new double[runs];
+		double[] maxErrors = new double[runs];
+
 		for(int i = 0; i<runs; i++) {
 			//optimise ellipsoids
 			final List<QuickEllipsoid> ellipsoids = runEllipsoidOptimisation(inputImage);
@@ -253,16 +256,16 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 				{
 					final Map<String, Double> errors = errorTracking.calculate(outputList.get(0));
 					errors.forEach((stat,value) -> logService.info(stat+": "+value.toString()));
-					SharedTable.add(inputImage.getName(),"median change "+i,errors.get("Median"));
-					SharedTable.add(inputImage.getName(),"maximum change "+i,errors.get("Max"));
+					medianErrors[i] = errors.get("Median");
+					maxErrors[i] = errors.get("Max");
 				}
 			}
 			else{
 				outputList = currentOutputList;
 				if(showConvergence)
 				{
-					SharedTable.add(inputImage.getName(), "median change " + i, 2);
-					SharedTable.add(inputImage.getName(), "maximum change " + i, 2);
+					medianErrors[i] = 2.0; // start with maximum possible error in first run (as no previous runs exist)
+					maxErrors[i] = 2.0;
 				}
 			}
 			counter++;
@@ -327,6 +330,11 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		SharedTable.add(inputImage.getName(), "Min EF", min);
 		if(showConvergence)
 		{
+			for(int i=0; i<runs; i++)
+			{
+				SharedTable.add(inputImage.getName(),"median change "+i, medianErrors[i]);
+				SharedTable.add(inputImage.getName(),"maximum change "+i, maxErrors[i]);
+			}
 			addResults(totalEllipsoids, fillingPercentage);
 		}
 		resultsTable = SharedTable.getTable();

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -76,6 +76,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imagej.units.UnitService;
 import net.imglib2.type.numeric.integer.ByteType;
@@ -288,7 +289,9 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 				// set spatial axis for first 3 dimensions (ID is 4d)
 				for(int dim = 0; dim<3; dim++)
 				{
-					imgPlus.setAxis(inputImage.axis(dim), dim);
+					CalibratedAxis axis = inputImage.axis(dim);
+					axis.setUnit(inputImage.axis(dim).unit());
+					imgPlus.setAxis(axis, dim);
 				}
 				if("Volume".equals(imgPlus.getName())) {
 					final Cursor<RealType> cursor = imgPlus.cursor();
@@ -457,6 +460,9 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 			final DefaultLinearAxis xAxis = (DefaultLinearAxis) inputImage.axis(0);
 			final DefaultLinearAxis yAxis = (DefaultLinearAxis) inputImage.axis(1);
 			final DefaultLinearAxis zAxis = (DefaultLinearAxis) inputImage.axis(2);
+			xAxis.setUnit(inputImage.axis(0).unit());
+			yAxis.setUnit(inputImage.axis(1).unit());
+			zAxis.setUnit(inputImage.axis(2).unit());
 			seedPointImage = new ImgPlus<>(seedImage, inputImage.getName().split("\\.")[0]+"_seed_points", xAxis, yAxis, zAxis);
 			seedPointImage.setChannelMaximum(0, 1);
 			seedPointImage.setChannelMinimum(0, 0);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -83,7 +83,6 @@ import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.scijava.ItemIO;
-import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
@@ -138,9 +137,6 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 		min = "0", style = NumberWidget.SPINNER_STYLE,
 		callback = "enforceAutoParam", required = false)
 	private long translations;
-
-	@Parameter(visibility = ItemVisibility.MESSAGE, required = false)
-	private String translationInfo = "NB: translations affect runtime significantly";
 
 	@Parameter(label = "Automatic parameters",
 		description = "Let the computer decide values for the parameters",

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -81,7 +81,6 @@ import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
 import org.joml.Vector3d;
 import org.scijava.ItemIO;
-import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
@@ -149,8 +148,7 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		description = "Nodes with centroids closer than this value to any image boundary will not be included in results",
 		style = NumberWidget.SPINNER_STYLE)
 	private int marginCutOff;
-	@Parameter(label = "Calibrated minimum length",
-		visibility = ItemVisibility.MESSAGE, persist = false)
+	@SuppressWarnings("unused")
 	private String realLength = "";
 	@Parameter(label = "Iterate pruning",
 		description = "If true, iterate pruning as long as short edges remain, or stop after a single pass",

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -302,7 +302,7 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 	}
 
 	private void prepareResults() {
-		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, '²');
+		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, "²");
 
 		if (isAxesMatchingSpatialCalibration(inputImage)) {
 			final double scale = inputImage.axis(0).averageScale(0.0, 1.0);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceFractionWrapper.java
@@ -98,7 +98,7 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 {
 
 	/** Header of ratio column in the results table */
-	private static final String ratioHeader = "Volume ratio";
+	private static final String ratioHeader = "BV/TV";
 	private static UnaryFunctionOp<RandomAccessibleInterval<?>, Mesh> marchingCubes;
 	private static UnaryFunctionOp<Mesh, DoubleType> meshVolume;
 	private static UnaryFunctionOp<RandomAccessibleInterval<?>, RandomAccessibleInterval> raiCopy;
@@ -193,9 +193,9 @@ public class SurfaceFractionWrapper<T extends RealType<T> & NativeType<T>> exten
 	private void prepareResultDisplay() {
 		final char exponent = ResultUtils.getExponent(inputImage);
 		final String unitHeader = ResultUtils.getUnitHeader(inputImage, unitService,
-			exponent);
-		bVHeader = "Bone volume " + unitHeader;
-		tVHeader = "Total volume " + unitHeader;
+			String.valueOf(exponent));
+		bVHeader = "BV " + unitHeader;
+		tVHeader = "TV " + unitHeader;
 		elementSize = ElementUtil.calibratedSpatialElementSize(inputImage,
 			unitService);
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtils.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtils.java
@@ -119,7 +119,7 @@ public final class ResultUtils {
 
 	/**
 	 * Returns a verbal description of the size of the elements in the given
-	 * space, e.g. "Area" for 2D images.
+	 * space, e.g. "A" for 2D images and "V" for 3D images.
 	 *
 	 * @param space an N-dimensional space.
 	 * @param <S> type of the space.
@@ -131,10 +131,10 @@ public final class ResultUtils {
 	{
 		final long dimensions = AxisUtils.countSpatialDimensions(space);
 		if (dimensions == 2) {
-			return "Area";
+			return "A";
 		}
 		if (dimensions == 3) {
-			return "Volume";
+			return "V";
 		}
 		return "Size";
 	}
@@ -154,7 +154,7 @@ public final class ResultUtils {
 	 * @return the unit string with the exponent.
 	 */
 	public static <S extends AnnotatedSpace<CalibratedAxis>> String getUnitHeader(
-		final S space, final UnitService unitService, final char exponent)
+		final S space, final UnitService unitService, final String exponent)
 	{
 		final Optional<String> unit = AxisUtils.getSpatialUnit(space, unitService);
 		if (!unit.isPresent()) {

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ConnectivityWrapperTest.java
@@ -148,8 +148,8 @@ public class ConnectivityWrapperTest extends AbstractWrapperTest {
 		// Create an test image of a cuboid
 		final String unit = "mm";
 		final List<String> expectedHeaders = Arrays.asList("Euler char. (χ)",
-			"Corrected Euler (χ + Δχ)", "Connectivity", String.format(
-				"Conn. density (%s³)", unit));
+			"Corr. Euler (χ + Δχ)", "Connectivity", String.format(
+				"Conn.D (%s⁻³)", unit));
 		final long size = 3;
 		final double scale = 0.9;
 		final long spaceSize = size * size * size;

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/ElementFractionWrapperTest.java
@@ -117,8 +117,8 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 		final double[] expectedRatios = { ratio, 0, 0, ratio };
 		final double[][] expectedValues = { expectedVolumes, expectedTotalVolumes,
 			expectedRatios };
-		final String[] expectedHeaders = { "Bone volume (" + unit + "³)",
-			"Total volume (" + unit + "³)", "Volume ratio" };
+		final String[] expectedHeaders = { "BV (" + unit + "³)",
+			"TV (" + unit + "³)", "BV/TV" };
 		// Create an hyperstack Img with a cube at (channel:0, frame:0) and (c:1,
 		// f:1)
 		final Img<BitType> img = ArrayImgs.bits(stackSide, stackSide, stackSide, 2,
@@ -172,8 +172,8 @@ public class ElementFractionWrapperTest extends AbstractWrapperTest {
 		final double[] expectedRatios = { 0, ratio };
 		final double[][] expectedValues = { expectedAreas, expectedTotalAreas,
 			expectedRatios };
-		final String[] expectedHeaders = { "Bone area (" + unit + "\u00B2)",
-			"Total area (" + unit + "\u00B2)", "Area ratio" };
+		final String[] expectedHeaders = { "BA (" + unit + "\u00B2)",
+			"TA (" + unit + "\u00B2)", "BA/TA" };
 		// Create an 2D image with two channels with a square drawn on channel 2
 		final Img<BitType> img = ArrayImgs.bits(stackSide, stackSide, 2);
 		Views.interval(img, new long[] { 1, 1, 1 }, new long[] { 5, 5, 1 }).forEach(

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapperTest.java
@@ -94,7 +94,7 @@ public class EllipsoidFactorWrapperTest extends AbstractWrapperTest {
         final CommandModule module = command().run(
                 EllipsoidFactorWrapper.class, true, "inputImage", empty, "nVectors", 100,
                 "vectorIncrement", 0.435, "skipRatio", 1, "contactSensitivity", 10, "maxIterations",
-                100, "maxDrift", 1.73, "minimumSemiAxis", 1.0, "runs", 1, "weightedAverageN", 1,
+                100, "maxDrift", 1.73, "runs", 1, "weightedAverageN", 1,
                 "seedOnDistanceRidge", true, "distanceThreshold", 0.6, "seedOnTopologyPreserving",
                 false).get();
 
@@ -119,7 +119,7 @@ public class EllipsoidFactorWrapperTest extends AbstractWrapperTest {
         final CommandModule module = command().run(
                 EllipsoidFactorWrapper.class, true, "inputImage", imgPlus, "nVectors", 100,
                 "vectorIncrement", 0.435, "skipRatio", 1, "contactSensitivity", 10, "maxIterations",
-                100, "maxDrift", 1.73, "minimumSemiAxis", 1.0, "runs", 1, "weightedAverageN", 1,
+                100, "maxDrift", 1.73, "runs", 1, "weightedAverageN", 1,
                 "seedOnDistanceRidge", true, "distanceThreshold", 0.6, "seedOnTopologyPreserving",
                 false).get();
 

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceFractionWrapperTest.java
@@ -117,8 +117,8 @@ public class SurfaceFractionWrapperTest extends AbstractWrapperTest {
 		final double totalVolume = ((imgWidth - 1) * (imgHeight - 1) * (imgDepth -
 			1)) * scaleCubed;
 		final double ratio = cubeVolume / totalVolume;
-		final String[] expectedHeaders = { "Bone volume (" + unit + "³)",
-			"Total volume (" + unit + "³)", "Volume ratio" };
+		final String[] expectedHeaders = { "BV (" + unit + "³)",
+			"TV (" + unit + "³)", "BV/TV" };
 		final double[][] expectedValues = { { 0.0, cubeVolume, cubeVolume, 0.0 }, {
 			totalVolume, totalVolume, totalVolume, totalVolume }, { 0.0, ratio, ratio,
 				0.0 } };

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/ResultUtilsTest.java
@@ -63,7 +63,6 @@ import java.util.stream.Stream;
 import net.imagej.ImageJ;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
-import net.imagej.axis.Axis;
 import net.imagej.axis.AxisType;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
@@ -116,7 +115,7 @@ public class ResultUtilsTest {
 
 	@Test
 	public void testGetSizeDescription() {
-		final String[] expected = { "Size", "Area", "Volume", "Size" };
+		final String[] expected = { "Size", "A", "V", "Size" };
 		final AxisType spatialAxis = Axes.get("Spatial", true);
 		final CalibratedAxis axis = new DefaultLinearAxis(spatialAxis);
 		final ImgPlus<?> mockImage = mock(ImgPlus.class);
@@ -139,7 +138,7 @@ public class ResultUtilsTest {
 	@Test
 	public void testGetUnitHeader() {
 		final String unit = "mm";
-		final char exponent = '³';
+		final String exponent = "³";
 		final DefaultLinearAxis axis = new DefaultLinearAxis(Axes.X, unit);
 		final Img<DoubleType> img = ArrayImgs.doubles(10);
 		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
@@ -156,14 +155,14 @@ public class ResultUtilsTest {
 		final Img<DoubleType> img = ArrayImgs.doubles(10);
 		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
 
-		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
+		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, "³");
 
 		assertTrue("Unit header should be empty", result.isEmpty());
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testGetUnitHeaderThrowsNPEIfSpaceNull() {
-		ResultUtils.getUnitHeader(null, unitService, '³');
+		ResultUtils.getUnitHeader(null, unitService, "³");
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -172,7 +171,7 @@ public class ResultUtilsTest {
 		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image",
 			new DefaultLinearAxis(Axes.X, "mm"));
 
-		ResultUtils.getUnitHeader(imgPlus, null, '³');
+		ResultUtils.getUnitHeader(imgPlus, null, "³");
 	}
 
 	@Test
@@ -212,7 +211,7 @@ public class ResultUtilsTest {
 		final Img<DoubleType> img = ArrayImgs.doubles(10);
 		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
 
-		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
+		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, "³");
 
 		assertEquals(expected, result);
 	}
@@ -225,7 +224,7 @@ public class ResultUtilsTest {
 		final Img<DoubleType> img = ArrayImgs.doubles(10);
 		final ImgPlus<DoubleType> imgPlus = new ImgPlus<>(img, "Test image", axis);
 
-		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, '³');
+		final String result = ResultUtils.getUnitHeader(imgPlus, unitService, "³");
 
 		assertEquals(expected, result);
 	}


### PR DESCRIPTION
This PR addresses issues with EF being a bit too verbose for most users, fixes a rarely-encountered bug in Particle Analyser, and restores Imax and Imin nomenclature to the previous in Slice Geometry (min & max refer now to the principal axes around which the moments are calculated, which has the effect that Imin > Imax in most cases).