### PR TITLE
Expand the allowable label space to use all positive int values

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -84,7 +84,9 @@ public class ConnectedComponents {
 	/** Background value */
 	public static final int BACK = 0;
 	/** 2^23 - greatest integer that can be represented precisely by a float */
-	static final int MAX_LABEL = 8388608;
+	public static final int MAX_FINAL_LABEL = 8388608;
+	/** maximum label value to use during intermediate processing */
+	static final int MAX_LABEL = Integer.MAX_VALUE;
 
 	/** number of particle labels */
 	private static int nParticles;

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -236,6 +236,9 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		final int[][] particleLabels = (int[][]) result[1];
 		final long[] particleSizes = (long[]) result[2];
 		final int nParticles = particleSizes.length;
+		
+		if (nParticles > ConnectedComponents.MAX_FINAL_LABEL)
+			IJ.log("Number of particles ("+nParticles+") exceeds the accurate display range (2^23) of the 32-bit float particle image");
 
 		final double[] volumes = ParticleAnalysis.getVolumes(imp, particleSizes);
 		


### PR DESCRIPTION
Addresses issue #276

Particle labels were previously capped at 2<sup>23</sup> which is the limit of integer precision represented by `float`. This limit was exceeded by large images (e.g. 150 GB) with many particles (3 million) running on computers with many threads (e.g. 132).

This solution allows the entire range of positive `int` (up to 2<sup>32</sup>) to be used during particle labelling and analysis of the resulting label array. The limitation of **displaying** labels in ImageJ1 as 32-bit `float` images remains.