### PR TITLE
Fix an AIOOB exception due to bad setting of chunk sizes

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -115,13 +115,20 @@ public class ConnectedComponents {
 		final int nProcessors = Runtime.getRuntime().availableProcessors();
 		final int minSlicesPerChunk = 10;
 
-		// set up number of chunks
-		final int nChunks = nSlices < minSlicesPerChunk * nProcessors
-				? (int) Math.ceil((double) nSlices / (double) minSlicesPerChunk)
-				: nProcessors;
-		// set up chunk sizes - last chunk is the remainder
-		final int slicesPerChunk = (int) Math.ceil((double) nSlices / (double) nChunks);
-
+		// set up number of chunks and chunk sizes
+		int nChunks = 1;
+		int slicesPerChunk = nSlices;
+		if (nSlices < minSlicesPerChunk) {
+			slicesPerChunk = nSlices;
+			nChunks = 1;
+		} else if (nSlices <= minSlicesPerChunk * nProcessors) {
+			slicesPerChunk = minSlicesPerChunk;
+			nChunks = (int) Math.ceil((double) nSlices / (double) minSlicesPerChunk); 
+		} else if (nSlices > minSlicesPerChunk * nProcessors) {
+			nChunks = nProcessors;
+			slicesPerChunk = (int) Math.floor((double) nSlices / (double) nChunks);
+		}
+		
 		// set up start slice array
 		final int[] startSlices = new int[nChunks];
 		for (int i = 0; i < nChunks; i++) {


### PR DESCRIPTION
This approach to setting chunk sizes no longer throws an AIOOB, but does
mean that the last chunk can be larger than the rest on big stacks.

Fixes #286