### PR TITLE
Calculate the aligned bounding box for each particle; performance enhancements

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -52,16 +52,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.bonej.plugins;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bonej.util.Multithreader;
 import org.eclipse.collections.api.iterator.MutableIntIterator;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.tuple.primitive.IntObjectPair;
 import org.eclipse.collections.impl.list.mutable.FastList;
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 
 import ij.ImagePlus;
@@ -178,7 +179,7 @@ public class ConnectedComponents {
 		// merge labels between the HashSets, handling the chunk offsets and indexes
 		bucketFountain(chunkMaps, chunkIDOffsets);
 		
-		HashMap<Integer, Integer> lutMap = makeLutMap(chunkMaps);
+		IntIntHashMap lutMap = makeLutMap(chunkMaps);
 
 		return lutFromLutMap(lutMap, chunkMaps, chunkIDOffsets);
 	}
@@ -519,7 +520,7 @@ public class ConnectedComponents {
 	 * @param chunkMaps list of collisions between labels
 	 * @return lutMap initial mapping of partial region labels to final labels
 	 */
-	private static HashMap<Integer, Integer> makeLutMap(final ArrayList<MutableList<IntHashSet>> chunkMaps) {
+	private static IntIntHashMap makeLutMap(final ArrayList<MutableList<IntHashSet>> chunkMaps) {
 		// count unique labels and particles
 		int labelCount = 0;
 		for (MutableList<IntHashSet> map : chunkMaps) {
@@ -531,7 +532,7 @@ public class ConnectedComponents {
 
 		// set up a 1D HashMap of HashSets with the minimum label
 		// set as the 'root' (key) of the hashMap
-		HashMap<Integer, IntHashSet> hashMap = new HashMap<>(labelCount);
+		IntObjectHashMap<IntHashSet> hashMap = new IntObjectHashMap<>(labelCount);
 		for (MutableList<IntHashSet> map : chunkMaps) {
 			for (IntHashSet set : map) {
 				if (!set.isEmpty())
@@ -540,7 +541,7 @@ public class ConnectedComponents {
 		}
 
 		// set up a LUT to keep track of the minimum replacement value for each label
-		final HashMap<Integer, Integer> lutMap = new HashMap<>(labelCount);
+		final IntIntHashMap lutMap = new IntIntHashMap(labelCount);
 		for (MutableList<IntHashSet> map : chunkMaps) {
 			for (IntHashSet set : map) {
 				// start so that each label looks up itself
@@ -552,9 +553,12 @@ public class ConnectedComponents {
 		boolean somethingChanged = true;
 		while (somethingChanged) {
 			somethingChanged = false;
-			for (Entry<Integer, IntHashSet> pair : hashMap.entrySet()) {
-				final IntHashSet set = pair.getValue();
-				final int key = pair.getKey();
+			Iterator<IntObjectPair<IntHashSet>> iterator2 = hashMap.keyValuesView().iterator();
+			while (iterator2.hasNext()) {
+			//for all the keyvalue pairs
+				IntObjectPair<IntHashSet> next = iterator2.next();
+				final int key = next.getOne();
+				final IntHashSet set = next.getTwo();
 				MutableIntIterator iterator = set.intIterator();
 				while (iterator.hasNext()) {
 					final int label = iterator.next();
@@ -593,19 +597,19 @@ public class ConnectedComponents {
 	 * @param chunkIDOffsets ID offsets
 	 * @return LUT as a 2D int array, with an int[] array per chunk
 	 */
-	private static int[][] lutFromLutMap(final HashMap<Integer, Integer> lutMap,
+	private static int[][] lutFromLutMap(final IntIntHashMap lutMap,
 			final ArrayList<MutableList<IntHashSet>> chunkMaps, final int[] chunkIDOffsets) {
 		// count number of unique labels in the LUT
 		IntHashSet lutLabels = new IntHashSet();
-		for (Map.Entry<Integer, Integer> pair : lutMap.entrySet()) {
-			lutLabels.add(pair.getValue());
-		}
+		lutMap.forEachValue(value -> {
+			lutLabels.add(value);
+		});
 		final int nLabels = lutLabels.size();
 		nParticles = nLabels;
 
 		// assign incremental replacement values
 		// translate old
-		final HashMap<Integer, Integer> lutLut = new HashMap<>(nLabels);
+		final IntIntHashMap lutLut = new IntIntHashMap(nLabels);
 		final AtomicInteger value = new AtomicInteger(1);
 		lutLabels.forEach(lutValue -> {
 			if (lutValue == 0) {
@@ -617,11 +621,11 @@ public class ConnectedComponents {
 
 		// lutLut now contains mapping from the old lut value (the lutLut 'key') to the
 		// new lut value (lutLut 'value')
-		for (Map.Entry<Integer, Integer> pair : lutMap.entrySet()) {
-			Integer oldLutValue = pair.getValue();
-			Integer newLutValue = lutLut.get(oldLutValue);
-			pair.setValue(newLutValue);
-		}
+		lutMap.forEachKey(key -> {
+			final int oldLutValue = lutMap.get(key);
+			final int newLutValue = lutLut.get(oldLutValue);
+			lutMap.put(key, newLutValue);
+		});
 
 		// translate the HashMap LUT to a chunkwise LUT, to be used in combination
 		// with the IDoffsets.

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ConnectedComponents.java
@@ -321,7 +321,7 @@ public class ConnectedComponents {
 									centre = getMinTag(nbh, ID);
 
 									// add neighbourhood to map
-									addNeighboursToMap(chunkMap, nbh, centre, IDoffset);
+									addNeighboursToMap13(chunkMap, nbh, centre, IDoffset);
 
 									// assign the smallest particle label from the
 									// neighbours to the pixel
@@ -708,6 +708,24 @@ public class ConnectedComponents {
 		}
 	}
 
+	/**
+	 * Check pixels one-by-one to decide what needs to be done, in order to 
+	 * reduce neighbourhood array lookups and map+set accesses.
+	 *
+	 * @param map      a map of LUT values.
+	 * @param nbh      a neighbourhood in the image.
+	 * @param centre   current pixel's label (with offset)
+	 * @param IDoffset chunk's ID offset
+	 */
+	private static void addNeighboursToMap13(final List<IntHashSet> map, final int[] nbh, final int centre,
+			final int IDoffset) {
+
+		if (nbh[4] == centre)
+			return;
+		
+		addNeighboursToMap(map, nbh, centre, IDoffset);
+	}
+	
 	/**
 	 * Add all the neighbouring labels of a pixel to the map, except 0 (background).
 	 * The LUT gets updated with the minimum neighbour found, but this is only

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Moments.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Moments.java
@@ -1047,9 +1047,9 @@ public class Moments implements PlugIn, DialogListener {
 				IJ.showProgress(z, dT);
 				final ImageProcessor targetIP = targetProcessors[z];
 				final double zD = z * vS - zTc;
-				final double zDeVI00 = zD * eVI20;
-				final double zDeVI01 = zD * eVI21;
-				final double zDeVI02 = zD * eVI22;
+				final double zDeVI20 = zD * eVI20;
+				final double zDeVI21 = zD * eVI21;
+				final double zDeVI22 = zD * eVI22;
 				for (int y = 0; y < hT; y++) {
 					final double yD = y * vS - yTc;
 					final double yDeVI10 = yD * eVI10;
@@ -1057,9 +1057,9 @@ public class Moments implements PlugIn, DialogListener {
 					final double yDeVI12 = yD * eVI12;
 					for (int x = 0; x < wT; x++) {
 						final double xD = x * vS - xTc;
-						final double xAlign = xD * eVI00 + yDeVI10 + zDeVI00 + xTc;
-						final double yAlign = xD * eVI01 + yDeVI11 + zDeVI01 + yTc;
-						final double zAlign = xD * eVI02 + yDeVI12 + zDeVI02 + zTc;
+						final double xAlign = xD * eVI00 + yDeVI10 + zDeVI20 + xTc;
+						final double yAlign = xD * eVI01 + yDeVI11 + zDeVI21 + yTc;
+						final double zAlign = xD * eVI02 + yDeVI12 + zDeVI22 + zTc;
 						// possibility to do some voxel interpolation instead
 						// of just rounding in next 3 lines
 						final int xA = (int) Math.floor((xAlign + dXc) / vW);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
@@ -574,9 +574,9 @@ public class ParticleAnalysis {
 					final double v12 = v[1][2];
 					final double v22 = v[2][2];
 					
-					final double xdv00 = xw * v00;
-					final double xdv01 = xw * v01;
-					final double xdv02 = xw * v02;
+					final double xwv00 = xw * v00;
+					final double xwv01 = xw * v01;
+					final double xwv02 = xw * v02;
 					final double yhv10 = yh * v10;
 					final double yhv11 = yh * v11;
 					final double yhv12 = yh * v12;
@@ -584,27 +584,46 @@ public class ParticleAnalysis {
 					final double zdv21 = zd * v21;
 					final double zdv22 = zd * v22;
 					
-					final double xT = xdv00 + yhv10 + zdv20;
-					final double yT = xdv01 + yhv11 + zdv21;
-					final double zT = xdv02 + yhv12 + zdv22;
+					final double l0 = xwv00 + yhv10 + zdv20;
+					final double l1 = xwv01 + yhv11 + zdv21;
+					final double l2 = xwv02 + yhv12 + zdv22;
 			
-					limits[i][0] = Math.min(limits[i][0], xT);
-					limits[i][1] = Math.max(limits[i][1], xT);
-					limits[i][2] = Math.min(limits[i][2], yT);
-					limits[i][3] = Math.max(limits[i][3], yT);
-					limits[i][4] = Math.min(limits[i][4], zT);
-					limits[i][5] = Math.max(limits[i][5], zT);
+					limits[i][0] = Math.min(limits[i][0], l0);
+					limits[i][1] = Math.max(limits[i][1], l0);
+					limits[i][2] = Math.min(limits[i][2], l1);
+					limits[i][3] = Math.max(limits[i][3], l1);
+					limits[i][4] = Math.min(limits[i][4], l2);
+					limits[i][5] = Math.max(limits[i][5], l2);
 				}
 			}
 		}
 		
 		final double[][] alignedBoxes = new double[nParticles][6];
 		
-		for (int i = 0; i < nParticles; i++) {
-			//centroid is average of the two limits
-			final double cx = (limits[i][0] + limits[i][1]) / 2;
-			final double cy = (limits[i][2] + limits[i][3]) / 2;
-			final double cz = (limits[i][4] + limits[i][5]) / 2;
+		for (int i = 1; i < nParticles; i++) {
+			//centroid in rotated coordinate frame is average of the two limits
+			final double c0 = (limits[i][0] + limits[i][1]) / 2; //long axis 0th column
+			final double c1 = (limits[i][2] + limits[i][3]) / 2; //medium axis 1st column
+			final double c2 = (limits[i][4] + limits[i][5]) / 2; //short axis 2nd column
+			
+			//rotate back to original coordinate frame by multiplying by the inverse
+			final double[][] vi = tensors[i].inverse().getArray();
+			
+			final double c2vi20 = c2 * vi[2][0];
+			final double c2vi21 = c2 * vi[2][1];
+			final double c2vi22 = c2 * vi[2][2];
+			
+			final double c1vi10 = c1 * vi[1][0];
+			final double c1vi11 = c1 * vi[1][1];
+			final double c1vi12 = c1 * vi[1][2];
+			
+			final double c0vi00 = c0 * vi[0][0];
+			final double c0vi01 = c0 * vi[0][1];
+			final double c0vi02 = c0 * vi[0][2];
+			
+			final double cx = c2vi20 + c1vi10 + c0vi00;
+			final double cy = c2vi21 + c1vi11 + c0vi01;
+			final double cz = c2vi22 + c1vi12 + c0vi02;
 			
 			//particle's length along each tensor axis is difference between limits
 			final double d0 = limits[i][1] - limits[i][0];

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleAnalysis.java
@@ -489,6 +489,7 @@ public class ParticleAnalysis {
 						final int index = y * w;
 						for (int x = 0; x < w; x++) {
 							final int p = slice[index + x];
+							if (p == 0) continue;
 							
 							threadSums[p][0] += x;
 							threadSums[p][1] += y;
@@ -526,7 +527,7 @@ public class ParticleAnalysis {
 		Iterator<int[][]> iter = listOfLimits.iterator();
 		while (iter.hasNext()) {
 			final int[][] threadLimits = iter.next();
-			for (int p = 0; p < nParticles; p++) {
+			for (int p = 1; p < nParticles; p++) {
 				final int[] threadP = threadLimits[p];
 				final int[] limitsP = limits[p];
 				limitsP[0] = Math.min(threadP[0], limitsP[0]);
@@ -542,7 +543,7 @@ public class ParticleAnalysis {
 		Iterator<double[][]> iterSums = listOfSums.iterator();
 		while (iterSums.hasNext()) {
 			final double[][] threadSums = iterSums.next();
-			for (int p = 0; p < nParticles; p++) {
+			for (int p = 1; p < nParticles; p++) {
 				sums[p][0] += threadSums[p][0];
 				sums[p][1] += threadSums[p][1];
 				sums[p][2] += threadSums[p][2];

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -159,6 +159,8 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		defaultValues[9] = false;
 		labels[10] = "Skeletons";
 		defaultValues[10] = false;
+		labels[11] = "Aligned boxes";
+		defaultValues[11] = false;
 		gd.addCheckboxGroup(6, 2, labels, defaultValues, headers);
 		gd.addNumericField("Min Volume", 0, 3, 7, units + "³");
 		gd.addNumericField("Max Volume", Double.POSITIVE_INFINITY, 3, 7, units +
@@ -185,7 +187,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		defaultValues2[7] = true;
 		labels2[8] = "Draw_ellipsoids";
 		defaultValues2[8] = false;
-		labels2[9] = "Show_aligned_boxes";
+		labels2[9] = "Show_aligned_boxes (3D)";
 		defaultValues2[9] = false;
 		gd.addCheckboxGroup(5, 2, labels2, defaultValues2, headers2);
 		final String[] items = { "Gradient", "Split", "Orientation"};
@@ -212,6 +214,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		final boolean doEllipsoids = gd.getNextBoolean();
 		final boolean doVerboseUnitVectors = gd.getNextBoolean();
 		final boolean doSkeletons = gd.getNextBoolean();
+		final boolean doAlignedBoxes = gd.getNextBoolean();
 		final boolean doParticleImage = gd.getNextBoolean();
 		final boolean doParticleSizeImage = gd.getNextBoolean();
 		final boolean doThickImage = gd.getNextBoolean();
@@ -251,12 +254,12 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		final int[][] limits = ParticleAnalysis.getParticleLimits(imp, particleLabels, nParticles);
 
 		EigenvalueDecomposition[] eigens = new EigenvalueDecomposition[nParticles];
-		if (doMoments || doAxesImage || colourMode == ParticleDisplay.ORIENTATION || doAlignedBoxesImage) {
+		if (doMoments || doAxesImage || colourMode == ParticleDisplay.ORIENTATION || doAlignedBoxes || doAlignedBoxesImage) {
 			eigens = ParticleAnalysis.getEigens(imp, particleLabels, centroids);
 		}
 		
 		double[][] alignedBoxes = new double[nParticles][6];
-		if (doAlignedBoxesImage) { //TODO include numerical results option
+		if (doAlignedBoxes || doAlignedBoxesImage) {
 			alignedBoxes = ParticleAnalysis.getAxisAlignedBoundingBoxes(imp, particleLabels, eigens, nParticles);
 		}
 		
@@ -320,6 +323,14 @@ public class ParticleCounter implements PlugIn, DialogListener {
 				rt.addValue("x Cent (" + units + ")", centroids[i][0]);
 				rt.addValue("y Cent (" + units + ")", centroids[i][1]);
 				rt.addValue("z Cent (" + units + ")", centroids[i][2]);
+				if (doAlignedBoxes) {
+					rt.addValue("Box x (" + units + ")", alignedBoxes[i][0]);
+					rt.addValue("Box y (" + units + ")", alignedBoxes[i][1]);
+					rt.addValue("Box z (" + units + ")", alignedBoxes[i][2]);
+					rt.addValue("Box l0 (" + units + ")", alignedBoxes[i][3]);
+					rt.addValue("Box l1 (" + units + ")", alignedBoxes[i][4]);
+					rt.addValue("Box l2 (" + units + ")", alignedBoxes[i][5]);
+				}
 				if (doSurfaceArea) {
 					rt.addValue("SA (" + units + "²)", surfaceAreas[i]);
 				}

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -248,9 +248,10 @@ public class ParticleCounter implements PlugIn, DialogListener {
 
 		final double[] volumes = ParticleAnalysis.getVolumes(imp, particleSizes);
 		
-		final double[][] centroids = ParticleAnalysis.getCentroids(imp, particleLabels,
-			particleSizes);
-		final int[][] limits = ParticleAnalysis.getParticleLimits(imp, particleLabels, nParticles);
+		final Object[] boxes = ParticleAnalysis.getBoundingBoxes(imp, particleLabels, particleSizes);
+		
+		final double[][] centroids = (double[][]) boxes[0];
+		final int[][] limits = (int[][]) boxes[1];
 
 		EigenvalueDecomposition[] eigens = new EigenvalueDecomposition[nParticles];
 		if (doMoments || doAxesImage || colourMode == ParticleDisplay.ORIENTATION || doAlignedBoxes || doAlignedBoxesImage) {

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -264,7 +264,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		}
 		
 		// set up resources for analysis
-		ArrayList<List<Point3f>> surfacePoints = new ArrayList<>();
+		List<List<Point3f>> surfacePoints = new ArrayList<>();
 		if (doSurfaceArea || doSurfaceVolume || doSurfaceImage || doEllipsoids ||
 			doFeret || doEllipsoidStack)
 		{

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -165,8 +165,8 @@ public class ParticleCounter implements PlugIn, DialogListener {
 			"³");
 		gd.addNumericField("Surface_resampling", 2, 0);
 		final String[] headers2 = { "Graphical Results", " " };
-		final String[] labels2 = new String[9];
-		final boolean[] defaultValues2 = new boolean[9];
+		final String[] labels2 = new String[10];
+		final boolean[] defaultValues2 = new boolean[10];
 		labels2[0] = "Show_particle stack";
 		defaultValues2[0] = true;
 		labels2[1] = "Show_size stack";
@@ -185,6 +185,8 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		defaultValues2[7] = true;
 		labels2[8] = "Draw_ellipsoids";
 		defaultValues2[8] = false;
+		labels2[9] = "Show_aligned_boxes";
+		defaultValues2[9] = false;
 		gd.addCheckboxGroup(5, 2, labels2, defaultValues2, headers2);
 		final String[] items = { "Gradient", "Split", "Orientation"};
 		gd.addChoice("Surface colours", items, items[0]);
@@ -221,6 +223,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		final boolean doEllipsoidImage = gd.getNextBoolean();
 		final boolean do3DOriginal = gd.getNextBoolean();
 		final boolean doEllipsoidStack = gd.getNextBoolean();
+		final boolean doAlignedBoxesImage = gd.getNextBoolean();
 		final int origResampling = (int) Math.floor(gd.getNextNumber());
 
 		// get the particles and do the analysis
@@ -248,8 +251,13 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		final int[][] limits = ParticleAnalysis.getParticleLimits(imp, particleLabels, nParticles);
 
 		EigenvalueDecomposition[] eigens = new EigenvalueDecomposition[nParticles];
-		if (doMoments || doAxesImage || colourMode == ParticleDisplay.ORIENTATION) {
+		if (doMoments || doAxesImage || colourMode == ParticleDisplay.ORIENTATION || doAlignedBoxesImage) {
 			eigens = ParticleAnalysis.getEigens(imp, particleLabels, centroids);
+		}
+		
+		double[][] alignedBoxes = new double[nParticles][6];
+		if (doAlignedBoxesImage) { //TODO include numerical results option
+			alignedBoxes = ParticleAnalysis.getAxisAlignedBoundingBoxes(imp, particleLabels, eigens, nParticles);
 		}
 		
 		// set up resources for analysis
@@ -417,7 +425,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 
 		// show 3D renderings
 		if (doSurfaceImage || doCentroidImage || doAxesImage || do3DOriginal ||
-			doEllipsoidImage)
+			doEllipsoidImage || doAlignedBoxesImage)
 		{
 
 			final Image3DUniverse univ = new Image3DUniverse();
@@ -443,6 +451,9 @@ public class ParticleCounter implements PlugIn, DialogListener {
 			}
 			if (do3DOriginal) {
 				ParticleDisplay.display3DOriginal(imp, origResampling, univ);
+			}
+			if (doAlignedBoxesImage) {
+				ParticleDisplay.displayAlignedBoundingBoxes(alignedBoxes, eigens, univ);
 			}
 			univ.show();
 		}

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -248,7 +248,6 @@ public class ParticleCounter implements PlugIn, DialogListener {
 
 		final double[] volumes = ParticleAnalysis.getVolumes(imp, particleSizes);
 		
-		//centroids and limits could run in separate threads - they do not depend on one another
 		final double[][] centroids = ParticleAnalysis.getCentroids(imp, particleLabels,
 			particleSizes);
 		final int[][] limits = ParticleAnalysis.getParticleLimits(imp, particleLabels, nParticles);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleDisplay.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleDisplay.java
@@ -353,6 +353,113 @@ public class ParticleDisplay {
 		}
 	}
 	
+	static void displayAlignedBoundingBoxes(double[][] alignedBoxes,
+		final EigenvalueDecomposition[] eigens, Image3DUniverse univ)
+	{
+		final int nBoxes = alignedBoxes.length;
+		
+		for (int p = 1; p < nBoxes; p++) {
+			final double[] box = alignedBoxes[p];
+			final double cx = box[0];
+			final double cy = box[1];
+			final double cz = box[2];
+			
+			//use half-lengths because vertex positions are calculated as an offset from the centre
+			final double l0 = box[3] / 2;
+			final double l1 = box[4] / 2;
+			final double l2 = box[5] / 2;
+			
+			//get the unit vectors
+			final double[][] eVec = eigens[p].getV().getArray();
+			final double eV0x = eVec[0][0];
+			final double eV0y = eVec[1][0];
+			final double eV0z = eVec[2][0];
+			final double eV1x = eVec[0][1];
+			final double eV1y = eVec[1][1];
+			final double eV1z = eVec[2][1];
+			final double eV2x = eVec[0][2];
+			final double eV2y = eVec[1][2];
+			final double eV2z = eVec[2][2];
+			
+			//calculate the 3 semi-axis vectors
+			final double v0x = l0 * eV0x;
+			final double v0y = l0 * eV0y;
+			final double v0z = l0 * eV0z;
+			
+			final double v1x = l1 * eV1x;
+			final double v1y = l1 * eV1y;
+			final double v1z = l1 * eV1z;
+			
+			final double v2x = l2 * eV2x;
+			final double v2y = l2 * eV2y;
+			final double v2z = l2 * eV2z;
+			
+			//calculate the positions of 8 vertices by summing the vector components
+			Point3f v0 = new Point3f();
+			v0.x = (float)(cx - v0x - v1x - v2x);
+			v0.y = (float)(cy - v0y - v1y - v2y);
+			v0.z = (float)(cz - v0z - v1z - v2z);
+			
+			Point3f v1 = new Point3f();
+			v1.x = (float)(cx - v0x + v1x - v2x);
+			v1.y = (float)(cy - v0y + v1y - v2y);
+			v1.z = (float)(cz - v0z + v1z - v2z);
+			
+			Point3f v2 = new Point3f();
+			v2.x = (float)(cx - v0x + v1x + v2x);
+			v2.y = (float)(cy - v0y + v1y + v2y);
+			v2.z = (float)(cz - v0z + v1z + v2z);
+			
+			Point3f v3 = new Point3f();
+			v3.x = (float)(cx - v0x - v1x + v2x);
+			v3.y = (float)(cy - v0y - v1y + v2y);
+			v3.z = (float)(cz - v0z - v1z + v2z);
+			
+			Point3f v4 = new Point3f();
+			v4.x = (float)(cx + v0x - v1x - v2x);
+			v4.y = (float)(cy + v0y - v1y - v2y);
+			v4.z = (float)(cz + v0z - v1z - v2z);
+			
+			Point3f v5 = new Point3f();
+			v5.x = (float)(cx + v0x + v1x - v2x);
+			v5.y = (float)(cy + v0y + v1y - v2y);
+			v5.z = (float)(cz + v0z + v1z - v2z);
+			
+			Point3f v6 = new Point3f();
+			v6.x = (float)(cx + v0x + v1x + v2x);
+			v6.y = (float)(cy + v0y + v1y + v2y);
+			v6.z = (float)(cz + v0z + v1z + v2z);
+			
+			Point3f v7 = new Point3f();
+			v7.x = (float)(cx + v0x - v1x + v2x);
+			v7.y = (float)(cy + v0y - v1y + v2y);
+			v7.z = (float)(cz + v0z - v1z + v2z);
+			
+			//construct a mesh with consecutive pairs of vertices for each edge
+			final List<Point3f> mesh = new ArrayList<>();
+			mesh.add(v0); mesh.add(v1);
+			mesh.add(v1); mesh.add(v2);
+			mesh.add(v2); mesh.add(v3);
+			mesh.add(v3); mesh.add(v0);
+			mesh.add(v0); mesh.add(v4);
+			mesh.add(v1); mesh.add(v5);
+			mesh.add(v2); mesh.add(v6);
+			mesh.add(v3); mesh.add(v7);
+			mesh.add(v4); mesh.add(v5);
+			mesh.add(v5); mesh.add(v6);
+			mesh.add(v6); mesh.add(v7);
+			mesh.add(v7); mesh.add(v4);
+			
+			final Color3f aColour = new Color3f(1.0f, 1.0f, 0.0f);
+			try {
+				univ.addLineMesh(mesh, aColour, "aligned box "+p, false).setLocked(true);
+			} catch (final NullPointerException npe) {
+				IJ.log("3D Viewer was closed before rendering completed.");
+			}
+		}
+		
+	}
+	
 	/**
 	 * Display Feret points and axis in the 3D Viewer
 	 * 


### PR DESCRIPTION
An axis-aligned bounding box has been implemented that takes the particle's principal axes as input and outputs the centroid and side length of the aligned bounding box. Users can choose to display numerical or 3D rendered results.

Addresses #288 

See the forum post for motivation and example output.
https://forum.image.sc/t/intersection-of-longest-principal-axis-and-object-surface/49105/8

Performance enhancements by
- multithreading analysis steps
- replacing Java Maps with Eclipse Collections primitive maps
- reducing neighbourhood handling during the first pass
- multithreading bucket fountain

Gains are most obvious on larger images (several GB) containing many particles; on very small images (2 MB) performance is similar or slower. Performance is also strongly affected by JRE optimisations, so 5 warm-up runs are recommended before taking measurements.

Using the s10up sample images:

pixels | master (ms) | aligned-box (ms) | nbh-decision-tree (ms) | multithread-bucket-fountain (ms)
-- | -- | -- | -- | --
2097152 | 52 | 59 | 55 | 82
2097152 | 62 | 58 | 60 | 55
2097152 | 45 | 52 | 70 | 48
2097152 | 70 | 93 | 48 | 46
2097152 | 54 | 59 | 50 | 53
16777216 | 216 | 140 | 141 | 172
16777216 | 171 | 193 | 163 | 157
16777216 | 146 | 165 | 183 | 189
16777216 | 196 | 137 | 128 | 158
16777216 | 202 | 186 | 211 | 144
134217728 | 1137 | 1002 | 1044 | 929
134217728 | 1070 | 1032 | 871 | 849
134217728 | 1134 | 1077 | 839 | 875
134217728 | 906 | 1290 | 1127 | 976
134217728 | 949 | 937 | 848 | 783
1073741824 | 8466 | 8014 | 7214 | 6318
1073741824 | 8250 | 6955 | 5989 | 6276
1073741824 | 8252 | 7133 | 6964 | 6239
1073741824 | 6621 | 6098 | 5652 | 6520
1073741824 | 6867 | 7361 | 5757 | 6426
7009835265 | 52688 | 50798 | 45447 | 48647
7009835265 | 50281 | 50944 | 41809 | 40914
7009835265 | 51344 | 45922 | 40795 | 43483
7009835265 | 54726 | 40896 | 37796 | 40491
7009835265 | 48201 | 38976 | 38965 | 35955
  |   **Average times (ms)**
2097152 | 56.6 | 64.2 | 56.6 | 56.8
16777216 | 186.2 | 164.2 | 165.2 | 164
134217728 | 1039.2 | 1067.6 | 945.8 | 882.4
1073741824 | 7691.2 | 7112.2 | 6315.2 | 6355.8
7009835265 | 51448 | 45507.2 | 40962.4 | 41898
  |   |  
**enhancements** | none | EC maps | EC maps, decision tree | all

Using the bglancy sample images


pixels | master (ms) | aligned-box (ms) | nbh-decision-tree (ms) | multithread-bucket-fountain (ms)
-- | -- | -- | -- | --
2097152 | 40 | 44 | 123 | 53
2097152 | 37 | 40 | 34 | 54
2097152 | 32 | 32 | 30 | 210
2097152 | 29 | 29 | 33 | 38
2097152 | 28 | 78 | 26 | 23
16777216 | 122 | 92 | 87 | 102
16777216 | 101 | 135 | 85 | 70
16777216 | 133 | 117 | 129 | 134
16777216 | 92 | 78 | 76 | 99
16777216 | 78 | 84 | 78 | 71
134217728 | 543 | 494 | 504 | 524
134217728 | 562 | 468 | 384 | 358
134217728 | 543 | 384 | 388 | 429
134217728 | 594 | 440 | 466 | 365
134217728 | 872 | 437 | 403 | 690
1073741824 | 5726 | 4562 | 4941 | 5877
1073741824 | 7204 | 3928 | 5313 | 4361
1073741824 | 6613 | 5002 | 5431 | 4917
1073741824 | 5372 | 3977 | 5199 | 5071
1073741824 | 5531 | 4213 | 4699 | 3536
8589934592 | 79427 | 49501 | 50670 | 41333
8589934592 | 69014 | 45375 | 46141 | 42721
8589934592 | 65565 | 49481 | 51481 | 45161
8589934592 | 56694 | 41562 | 41321 | 34487
8589934592 | 58830 | 41195 | 45756 | 37789
  | **Average Times (ms)**   |   |   |  
2097152 | 33.2 | 44.6 | 49.2 | 75.6
16777216 | 105.2 | 101.2 | 91 | 95.2
134217728 | 622.8 | 444.6 | 429 | 473.2
1073741824 | 6089.2 | 4336.4 | 5116.6 | 4752.4
7009835265 | 65906 | 45422.8 | 47073.8 | 40298.2
  |   |   |   |  
**enhancements** | none | EC maps | EC maps, decision tree | all


