### PR TITLE
UI tweaks

### DIFF
--- a/Legacy/bonej/pom.xml
+++ b/Legacy/bonej/pom.xml
@@ -13,7 +13,7 @@
 
     <name>BoneJ legacy plugins</name>
     <description>Mavenized version of the BoneJ1 plugins</description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2015</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Moments.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Moments.java
@@ -166,6 +166,7 @@ public class Moments implements PlugIn, DialogListener {
 		gd.addCheckbox("Show axes (3D)", true);
 		gd.addCheckbox("Record unit vectors", false);
 		gd.addDialogListener(this);
+		gd.addHelp("https://imagej.net/plugins/bonej#moments-of-inertia");
 		gd.showDialog();
 		if (gd.wasCanceled()) {
 			return;

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ParticleCounter.java
@@ -194,7 +194,7 @@ public class ParticleCounter implements PlugIn, DialogListener {
 		gd.addChoice("Surface colours", items, items[0]);
 		gd.addNumericField("Split value", 0, 3, 7, units + "³");
 		gd.addNumericField("Volume_resampling", 2, 0);
-		gd.addHelp("https://imagej.github.io/plugins/bonej#particle-analyser");
+		gd.addHelp("https://imagej.net/plugins/bonej#particle-analyser");
 		gd.addDialogListener(this);
 		gd.showDialog();
 		if (gd.wasCanceled()) {

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Purify.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Purify.java
@@ -99,6 +99,7 @@ public class Purify implements PlugIn {
 		final GenericDialog gd = new GenericDialog("Setup");
 		gd.addCheckbox("Performance Log", false);
 		gd.addCheckbox("Make_copy", true);
+		gd.addHelp("https://imagej.net/plugins/bonej#purify");
 		gd.showDialog();
 		if (gd.wasCanceled()) return;
 		final boolean showPerformance = gd.getNextBoolean();

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/ReporterOptions.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/ReporterOptions.java
@@ -78,7 +78,7 @@ public class ReporterOptions implements PlugIn {
 			"and promote BoneJ to funders.");
 		dialog.addMessage("If you agree to participate please hit OK\n" +
 			"otherwise, cancel. For more information click Help.");
-		dialog.addHelp("https://imagej.github.io/plugins/bonej#usage-reporting");
+		dialog.addHelp("https://imagej.net/plugins/bonej#usage-reporting");
 		dialog.showDialog();
 		if (dialog.wasCanceled()) {
 			Prefs.set(OPTOUTKEY, false);

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/SliceGeometry.java
@@ -274,7 +274,7 @@ public class SliceGeometry implements PlugIn, DialogListener {
 		gd.addCheckbox("Partial_volume_compensation", false);
 		gd.addNumericField("Background", thresholds[0], 1, 6, pixUnits + " ");
 		gd.addNumericField("Foreground", thresholds[1], 1, 6, pixUnits + " ");
-		gd.addHelp("https://imagej.github.io/plugins/bonej#slice-geometry");
+		gd.addHelp("https://imagej.net/plugins/bonej#slice-geometry");
 		gd.addDialogListener(this);
 		gd.showDialog();
 		final String bone = gd.getNextChoice();

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/SphereFitter.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/SphereFitter.java
@@ -128,6 +128,7 @@ public class SphereFitter implements PlugIn, DialogListener {
 		gd.addCheckbox("Add_to_ROI_Manager", false);
 		gd.addCheckbox("Clear_ROI_Manager", false);
 		gd.addDialogListener(this);
+		gd.addHelp("https://imagej.net/plugins/bonej#fit-sphere");
 		gd.showDialog();
 		if (gd.wasCanceled()) {
 			return;

--- a/Legacy/bonej/src/main/resources/plugins.config
+++ b/Legacy/bonej/src/main/resources/plugins.config
@@ -29,9 +29,9 @@
 ###
 # Author: Michael Doube
 
-Plugins>BoneJ>Analyze, "Calibrate SCANCO", org.bonej.plugins.DensityCalibrator("scanco")
-Plugins>BoneJ>Analyze, "Orientation", org.bonej.plugins.Orienteer
-Plugins>BoneJ>Analyze, "Particle Analyser", org.bonej.plugins.ParticleCounter
+Plugins>BoneJ>Analyse, "Calibrate SCANCO", org.bonej.plugins.DensityCalibrator("scanco")
+Plugins>BoneJ>Analyse, "Orientation", org.bonej.plugins.Orienteer
+Plugins>BoneJ>Analyse, "Particle Analyser", org.bonej.plugins.ParticleCounter
 
 Plugins>BoneJ>Connectivity, "Connectivity", org.bonej.plugins.Connectivity 
 

--- a/Legacy/util/pom.xml
+++ b/Legacy/util/pom.xml
@@ -13,7 +13,7 @@
 
     <name>BoneJ legacy utilities</name>
     <description>Utility classes for BoneJ1 plugins</description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2015</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>

--- a/Modern/ops/pom.xml
+++ b/Modern/ops/pom.xml
@@ -13,7 +13,7 @@
 
     <name>BoneJ2 Ops</name>
     <description>Ops created for BoneJ2</description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2015</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>

--- a/Modern/utilities/pom.xml
+++ b/Modern/utilities/pom.xml
@@ -13,7 +13,7 @@
 
     <name>BoneJ2 utilities</name>
     <description>Utility methods for BoneJ2</description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2015</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>

--- a/Modern/wrapperPlugins/pom.xml
+++ b/Modern/wrapperPlugins/pom.xml
@@ -16,7 +16,7 @@
         The Domain Presentation Layer (DPL) of BoneJ2, i.e. the commands that wrap the needed ops,
         and present results for skeletal biologists.
     </description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2015</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnalyseSkeletonWrapper.java
@@ -80,6 +80,7 @@ import org.apache.commons.math3.util.MathArrays;
 import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ImagePlusUtil;
 import org.bonej.utilities.SharedTable;
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
@@ -88,6 +89,7 @@ import org.scijava.convert.ConvertService;
 import org.scijava.io.IOService;
 import org.scijava.io.location.FileLocation;
 import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.table.DefaultGenericTable;
@@ -95,6 +97,7 @@ import org.scijava.table.DoubleColumn;
 import org.scijava.table.IntColumn;
 import org.scijava.table.PrimitiveColumn;
 import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 import org.scijava.widget.ChoiceWidget;
 import org.scijava.widget.FileWidget;
 
@@ -150,6 +153,9 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 		description = "Show skeleton images labelled with their IDs",
 		required = false)
 	private boolean displaySkeletons;
+	
+	@Parameter(label = "Help", description = "More about Analyse Skeleton", callback = "showHelpPage")
+	private Button button;
 
 	/**
 	 * Additional analysis details in a {@link DefaultGenericTable}, null if
@@ -189,7 +195,10 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 
 	@Parameter
 	private StatusService statusService;
-
+	
+	@Parameter
+	private PlatformService platformService;
+	
 	private ImagePlus intensityImage;
 
 	@Override
@@ -230,6 +239,11 @@ public class AnalyseSkeletonWrapper extends BoneJCommand {
 			}
 		}
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#analyse-skeleton", platformService, uiService, logService);
 	}
 
 	private boolean hasNoSkeletons(final AnalyzeSkeleton_ analyzeSkeleton_) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/AnisotropyWrapper.java
@@ -100,6 +100,7 @@ import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.utilities.Visualiser;
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.joml.Matrix3d;
 import org.joml.Matrix4d;
@@ -112,10 +113,12 @@ import org.scijava.ItemVisibility;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.DialogPrompt.Result;
 import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 import org.scijava.widget.NumberWidget;
 
 /**
@@ -194,6 +197,9 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 			description = "Show the vectors of the mean intercept lengths",
 			required = false)
 	private boolean displayMILVectors;
+	
+	@Parameter(label = "Help", description = "More about Anisotropy", callback = "showHelpPage")
+	private Button button;
 
 	@Parameter
 	private LogService logService;
@@ -205,6 +211,8 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 	private UIService uiService;
 	@Parameter
 	private UnitService unitService;
+	@Parameter
+	private PlatformService platformService;
 	private static BinaryHybridCFI1<Vector3d, Quaterniondc, Vector3d> rotateOp;
 	private double milLength;
 
@@ -228,6 +236,11 @@ public class AnisotropyWrapper<T extends RealType<T> & NativeType<T>> extends Bo
 		addResults(subspaces, ellipsoids);
 		resultsTable = SharedTable.getTable();
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#anisotropy", platformService, uiService, logService);
 	}
 
 	// region -- Helper methods --

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/EllipsoidFactorWrapper.java
@@ -118,9 +118,11 @@ import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 
 import sc.fiji.skeletonize3D.Skeletonize3D_;
 
@@ -166,6 +168,8 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	@SuppressWarnings("unused")
     @Parameter
 	private UnitService unitService;
+	@Parameter
+	private PlatformService platformService;
 	//main input image
 	@SuppressWarnings("unused")
 	@Parameter(validater = "validateImage")
@@ -213,7 +217,9 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 	private List<ImgPlus> ellipsoidFactorOutputImages;
 	@Parameter(label = "Seed Points", type = ItemIO.OUTPUT)
 	private ImgPlus<ByteType> seedPointImage;// 0=not a seed, 1=medial seed
-
+	@Parameter(label = "Help", description = "More about Ellipsoid Factor", callback = "showHelpPage")
+	private Button button;
+	
 	private ImgPlus<BitType> inputAsBitType;
 
 	@Override
@@ -340,6 +346,11 @@ public class EllipsoidFactorWrapper extends BoneJCommand {
 		resultsTable = SharedTable.getTable();
 		statusService.showStatus("Ellipsoid Factor completed");
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#ellipsoid-factor", platformService, uiService, logService);
 	}
 
 	private List<ImgPlus> divideOutput(final List<ImgPlus> outputList, final int repetitions) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FractalDimensionWrapper.java
@@ -81,15 +81,20 @@ import org.apache.commons.math3.fitting.WeightedObservedPoints;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.table.DefaultGenericTable;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.GenericTable;
+import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 import org.scijava.widget.NumberWidget;
 
 /**
@@ -147,6 +152,9 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 	@Parameter(label = "Show points",
 		description = "Show (log(size), -log(count)) points", required = false)
 	private boolean showPoints;
+	
+	@Parameter(label = "Help", description = "More about Fractal Dimension", callback = "showHelpPage")
+	private Button button;
 
 	/**
 	 * Table containing the (-log(size), log(count)) points for each 3D subspace
@@ -158,6 +166,12 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 	private OpService opService;
 	@Parameter
 	private StatusService statusService;
+	@Parameter
+	private LogService logService;
+	@Parameter
+	private UIService uiService;
+	@Parameter
+	private PlatformService platformService;
 
 	private BinaryHybridCF<RandomAccessibleInterval<BitType>, Boolean, RandomAccessibleInterval<BitType>> hollowOp;
 	private UnaryFunctionOp<RandomAccessibleInterval<BitType>, List<ValuePair<DoubleType, DoubleType>>> boxCountOp;
@@ -194,6 +208,12 @@ public class FractalDimensionWrapper<T extends RealType<T> & NativeType<T>> exte
 		resultsTable = SharedTable.getTable();
 		reportUsage();
 	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#fractal-dimension", platformService, uiService, logService);
+	}
+	
 
 	// region -- Helper methods --
 	private void writePoints(final String headerSuffix,

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -83,11 +83,14 @@ import org.joml.Vector3d;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.table.DoubleColumn;
 import org.scijava.table.Table;
 import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 import org.scijava.widget.NumberWidget;
 
 import sc.fiji.analyzeSkeleton.AnalyzeSkeleton_;
@@ -166,6 +169,7 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		description = "Print the percentage of each of the type of edges that were culled after calling analyseSkeleton",
 		required = false, persistKey = "ITA_print_culled_edges")
 	private boolean printCulledEdgePercentages;
+
 	/**
 	 * The ITA edge-end coordinates in a {@link Table}, null if there are no
 	 * results
@@ -174,10 +178,16 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 	private ResultsTable centroidTable;
 	@Parameter(type = ItemIO.OUTPUT, label = "Edge culling percentages")
 	private ResultsTable culledEdgePercentagesTable;
+	@Parameter(label = "Help", description = "More about Intertrabecular Angles", callback = "showHelpPage")
+	private Button button;
 	@Parameter
 	private StatusService statusService;
 	@Parameter
 	private UIService uiService;
+	@Parameter
+	private LogService logService;
+	@Parameter
+	private PlatformService platformService;
 
 	private double[] coefficients;
 	private boolean anisotropyWarned;
@@ -218,6 +228,11 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		printEdgeCentroids(cleanGraph.getEdges());
 		printCulledEdgePercentages(pruningResult.b);
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#inter-trabecular-angles", platformService, uiService, logService);
 	}
 
 	private void addResults(final Map<Integer, DoubleStream> anglesMap) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -90,15 +90,18 @@ import net.imglib2.type.numeric.real.DoubleType;
 import org.bonej.utilities.AxisUtils;
 import org.bonej.utilities.ElementUtil;
 import org.bonej.utilities.SharedTable;
+import org.bonej.wrapperPlugins.wrapperUtils.Common;
 import org.bonej.wrapperPlugins.wrapperUtils.HyperstackUtils.Subspace;
 import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
 import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
 import org.scijava.util.StringUtils;
+import org.scijava.widget.Button;
 import org.scijava.widget.FileWidget;
 
 /**
@@ -123,6 +126,8 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 		description = "Create a binary STL file from the surface mesh",
 		required = false)
 	private boolean exportSTL;
+	@Parameter(label = "Help", description = "More about Surface Area", callback = "showHelpPage")
+	private Button button;
 	@Parameter
 	private OpService opService;
 	@Parameter
@@ -133,6 +138,8 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 	private UnitService unitService;
 	@Parameter
 	private StatusService statusService;
+	@Parameter
+	private PlatformService platformService;
 
 	private String path = "";
 	private String extension = "";
@@ -157,6 +164,11 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 		calculateAreas(meshes);
 		resultsTable = SharedTable.getTable();
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#surface-area", platformService, uiService, logService);
 	}
 
 	/**

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -77,9 +77,12 @@ import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
+import org.scijava.log.LogService;
+import org.scijava.platform.PlatformService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
 import org.scijava.widget.ChoiceWidget;
 
 import sc.fiji.localThickness.LocalThicknessWrapper;
@@ -120,11 +123,18 @@ public class ThicknessWrapper extends BoneJCommand {
 
 	@Parameter(label = "Trabecular spacing", type = ItemIO.OUTPUT)
 	private ImagePlus spacingMap;
+	
+	@Parameter(label = "Help", description = "More about Thickness", callback = "showHelpPage")
+	private Button button;
 
 	@Parameter
 	private UIService uiService;
 	@Parameter
 	private StatusService statusService;
+	@Parameter
+	private LogService logService;
+	@Parameter
+	private PlatformService platformService;
 
 	private boolean foreground;
 	private LocalThicknessWrapper localThickness;
@@ -160,6 +170,11 @@ public class ThicknessWrapper extends BoneJCommand {
 			}
 		}
 		reportUsage();
+	}
+	
+	@SuppressWarnings("unused")
+	private void showHelpPage() {
+		Common.showHelpPage("#thickness", platformService, uiService, logService);
 	}
 
 	private void addMapResults(final ImagePlus map) {

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
@@ -55,6 +55,9 @@ import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 import static org.scijava.ui.DialogPrompt.OptionType.OK_CANCEL_OPTION;
 import static org.scijava.ui.DialogPrompt.Result.OK_OPTION;
 
+import java.io.IOException;
+import java.net.URL;
+
 import net.imagej.ImgPlus;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.display.ColorTables;
@@ -69,6 +72,8 @@ import org.bonej.utilities.ImagePlusUtil;
 import org.scijava.Context;
 import org.scijava.command.ContextCommand;
 import org.scijava.log.LogService;
+import org.scijava.log.Logger;
+import org.scijava.platform.PlatformService;
 import org.scijava.ui.UIService;
 
 import ij.ImagePlus;
@@ -177,6 +182,25 @@ public final class Common {
 		for (int d = 0; d < dimensions; d++) {
 			final CalibratedAxis axis = source.axis(d);
 			target.setAxis(axis, d);
+		}
+	}
+	
+	/**
+	 * Shows a  help page on the imagej.net website, direction to the section indicated by 'section'.
+	 * 
+	 * @param section on the webpage in the format '#page-section'. If empty or not found,
+	 *  webpage opens at the top
+	 *  @param platformService
+	 * @param uiService 
+	 * @param logService 
+	 */
+	public static void showHelpPage(String section,
+		PlatformService platformService, UIService uiService, Logger logService) {
+		try {
+			platformService.open(new URL("https://imagej.net/plugins/bonej"+section));
+		} catch (final IOException e) {
+			uiService.showDialog("Something went wrong while opening the help page. Please try again.");
+			logService.trace(e);
 		}
 	}
 }

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/UsageReporterOptions.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/UsageReporterOptions.java
@@ -149,7 +149,7 @@ public class UsageReporterOptions extends ContextCommand {
 	@SuppressWarnings("unused")
 	private void showHelpPage() {
 		try {
-			platformService.open(new URL("https://imagej.github.io/plugins/bonej#usage-reporting"));
+			platformService.open(new URL("https://imagej.net/plugins/bonej#usage-reporting"));
 		} catch (final IOException e) {
 			uiService.showDialog("Something went wrong while opening the help page. Please try again.");
 			logService.trace(e);

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/UsageReporterOptions.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/UsageReporterOptions.java
@@ -148,11 +148,6 @@ public class UsageReporterOptions extends ContextCommand {
 
 	@SuppressWarnings("unused")
 	private void showHelpPage() {
-		try {
-			platformService.open(new URL("https://imagej.net/plugins/bonej#usage-reporting"));
-		} catch (final IOException e) {
-			uiService.showDialog("Something went wrong while opening the help page. Please try again.");
-			logService.trace(e);
-		}
+		Common.showHelpPage("#usage-reporting", platformService, uiService, logService);
 	}
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BoneJ is a collection of Fiji/ImageJ plug-ins for skeletal biology. It provides 
 > doi:[10.12688/wellcomeopenres.16619.1](https://doi.org/10.12688/wellcomeopenres.16619.1)
 
 ## Links
-* [User guide](https://imagej.github.io/plugins/bonej)
+* [User guide](https://imagej.net/plugins/bonej)
 * [ImageJ forum](https://forum.image.sc/tags/bonej)
 * [Developer documentation](https://github.com/bonej-org/BoneJ2/wiki)
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <name>BoneJ Parent POM</name>
     <description>Parent POM for BoneJ components</description>
-    <url>https://imagej.github.io/plugins/bonej</url>
+    <url>https://imagej.net/plugins/bonej</url>
     <inceptionYear>2016</inceptionYear>
     <organization>
         <name>Royal Veterinary College</name>


### PR DESCRIPTION
- Fix some spelling to make 'Analyse' consistent across BoneJ (using the 'z' spelling for Ignacio's original AnalyzeSkeleton, but Analyse for BoneJ's wrapper).

- Use the imagej.net/plugins/bonej URL format as far as possible for user docs.

- Add Help buttons to plugins' dialogs, which point to imagej.net/plugins/bonej sections.

Partially addresses #295 
