### PR TITLE
Refactor image anisotropy check to handle headless execution.

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/FitEllipsoidWrapper.java
@@ -81,6 +81,7 @@ import org.joml.Vector3d;
 import org.joml.Vector3dc;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
@@ -111,6 +112,8 @@ public class FitEllipsoidWrapper extends BoneJCommand {
 	private StatusService statusService;
 	@Parameter
 	private UIService uiService;
+	@Parameter
+	private LogService logService;
 
 	private List<Vector3d> points;
 
@@ -180,7 +183,7 @@ public class FitEllipsoidWrapper extends BoneJCommand {
 			cancelMacroSafe(this, NOT_3D_IMAGE);
 			return;
 		}
-		if (!Common.warnAnisotropy(inputImage, uiService)) {
+		if (!Common.warnAnisotropy(inputImage, uiService, logService)) {
 			cancel(null);
 		}
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -298,14 +298,8 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		}
 		// Without anisotropyWarned the warning is shown twice
 		if (!anisotropyWarned) {
-			if (uiService.isHeadless() && ImagePlusUtil.anisotropy(inputImage) < 1E-3) {
-				logService.warn("Image is anisotropic, results are likely to be wrong.");
-			}
-			else {
-				//warnAnisotropy needs to be refactored to remove dependence on UI
-				if (!Common.warnAnisotropy(inputImage, uiService)) {
-					cancel(null);
-				}
+			if (!Common.warnAnisotropy(inputImage, uiService, logService)) {
+				cancel(null);
 			}
 			anisotropyWarned = true;
 		}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -77,6 +77,7 @@ import org.bonej.wrapperPlugins.wrapperUtils.ResultUtils;
 import org.scijava.ItemIO;
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
@@ -123,6 +124,8 @@ public class ThicknessWrapper extends BoneJCommand {
 
 	@Parameter
 	private UIService uiService;
+	@Parameter
+	private LogService logService;
 	@Parameter
 	private StatusService statusService;
 
@@ -257,7 +260,7 @@ public class ThicknessWrapper extends BoneJCommand {
 		}
 
 		if (!anisotropyWarned) {
-			if (!Common.warnAnisotropy(inputImage, uiService)) {
+			if (!Common.warnAnisotropy(inputImage, uiService, logService)) {
 				cancel(null);
 			}
 			anisotropyWarned = true;

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
@@ -118,7 +118,7 @@ public final class Common {
 
 	/**
 	 * Shows a warning dialog about image anisotropy, and asks if the user wants
-	 * to continue. If the 
+	 * to continue. If the plugin is running in headless mode, execution continues anyway, and a warning is printed to the log.
 	 *
 	 * @param image the current image open in ImageJ.
 	 * @param uiService used to display the warning dialog.

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/wrapperUtils/Common.java
@@ -118,15 +118,16 @@ public final class Common {
 
 	/**
 	 * Shows a warning dialog about image anisotropy, and asks if the user wants
-	 * to continue.
+	 * to continue. If the 
 	 *
 	 * @param image the current image open in ImageJ.
 	 * @param uiService used to display the warning dialog.
-	 * @return true if user chose OK_OPTION, or image is not anisotropic. False if
-	 *         user chose 'cancel' or they closed the dialog.
+	 * @param logService handles the warning text if the UI is headless
+	 * @return true if user chose OK_OPTION, or image is not anisotropic, or
+	 * execution is headless. False if user chose 'cancel' or they closed the dialog.
 	 */
 	public static boolean warnAnisotropy(final ImagePlus image,
-		final UIService uiService)
+		final UIService uiService, final LogService logService)
 	{
 		final double anisotropy = ImagePlusUtil.anisotropy(image);
 		if (anisotropy < 1E-3) {
@@ -134,6 +135,12 @@ public final class Common {
 		}
 		final String anisotropyPercent = String.format("(%.1f %%)", anisotropy *
 			100.0);
+		if (uiService.isHeadless()) {
+			logService.warn("The image is anisotropic " +
+					anisotropyPercent + ". Continuing anyway, but results "
+							+ "may be unreliable");
+			return true;
+		}
 		return uiService.showDialog("The image is anisotropic " +
 			anisotropyPercent + ". Continue anyway?", WARNING_MESSAGE,
 			OK_CANCEL_OPTION) == OK_OPTION;

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/CommonTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/wrapperUtils/CommonTest.java
@@ -154,8 +154,8 @@ public class CommonTest {
 		final UIService uiService = mock(UIService.class);
 		when(uiService.showDialog(anyString(), any(MessageType.class), any()))
 			.thenReturn(CANCEL_OPTION);
-
-		assertFalse(Common.warnAnisotropy(imagePlus, uiService));
+		final LogService logService = mock(LogService.class);
+		assertFalse(Common.warnAnisotropy(imagePlus, uiService, logService));
 		verify(uiService, timeout(1000)).showDialog(anyString(), any(
 			MessageType.class), any());
 	}
@@ -171,7 +171,8 @@ public class CommonTest {
 		when(uiService.showDialog(anyString(), any(MessageType.class), any()))
 			.thenReturn(CLOSED_OPTION);
 
-		assertFalse(Common.warnAnisotropy(imagePlus, uiService));
+		final LogService logService = mock(LogService.class);
+		assertFalse(Common.warnAnisotropy(imagePlus, uiService, logService));
 		verify(uiService, timeout(1000)).showDialog(anyString(), any(
 			MessageType.class), any());
 	}
@@ -187,7 +188,8 @@ public class CommonTest {
 		when(uiService.showDialog(anyString(), any(MessageType.class), any()))
 			.thenReturn(OK_OPTION);
 
-		assertTrue(Common.warnAnisotropy(imagePlus, uiService));
+		final LogService logService = mock(LogService.class);
+		assertTrue(Common.warnAnisotropy(imagePlus, uiService, logService));
 		verify(uiService, timeout(1000)).showDialog(anyString(), any(
 			MessageType.class), any());
 	}
@@ -200,17 +202,23 @@ public class CommonTest {
 		when(imagePlus.getCalibration()).thenReturn(isotropic);
 		final UIService uiService = mock(UIService.class);
 
-		assertTrue(Common.warnAnisotropy(imagePlus, uiService));
+		final LogService logService = mock(LogService.class);
+		assertTrue(Common.warnAnisotropy(imagePlus, uiService, logService));
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testWarnAnisotropyThrowsNPEIfImageNull() {
-		Common.warnAnisotropy(null, mock(UIService.class));
+		Common.warnAnisotropy(null, mock(UIService.class), mock(LogService.class));
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testWarnAnisotropyThrowsNPEIfUIServiceNull() {
-		Common.warnAnisotropy(mock(ImagePlus.class), null);
+		Common.warnAnisotropy(mock(ImagePlus.class), null, mock(LogService.class));
+	}
+	
+	@Test(expected = NullPointerException.class)
+	public void testWarnAnisotropyThrowsNPEIfLogServiceNull() {
+		Common.warnAnisotropy(mock(ImagePlus.class), mock(UIService.class), null);
 	}
 
 	@Test


### PR DESCRIPTION
The anisotropy check previously always showed a GUI if the image was anisotropic, but this broke headless execution. If code is called from a headless environment, e.g. a Python script, a warning is printed to the console and execution continues, even if results may be unreliable.