### PR TITLE
Intertrabecular Angles: optionally show the skeleton image using Parameter conventions

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -400,7 +400,6 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		final int iterations = skeletoniser.getThinningIterations();
 		if (iterations > 1) {
 			skeleton.setTitle("Skeleton of " + inputImage.getTitle());
-			uiService.show(skeleton);
 		}
 		return skeleton;
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapper.java
@@ -166,6 +166,10 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		description = "Print the percentage of each of the type of edges that were culled after calling analyseSkeleton",
 		required = false, persistKey = "ITA_print_culled_edges")
 	private boolean printCulledEdgePercentages;
+	@Parameter(label = "Show skeleton",
+		description = "Show skeletonisation",
+		required = false, persistKey = "ITA_show_skeleton")
+	private boolean showSkeleton = false;
 	/**
 	 * The ITA edge-end coordinates in a {@link Table}, null if there are no
 	 * results
@@ -174,6 +178,11 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 	private ResultsTable centroidTable;
 	@Parameter(type = ItemIO.OUTPUT, label = "Edge culling percentages")
 	private ResultsTable culledEdgePercentagesTable;
+	/**
+	 * Skeletonised image
+	 */
+	@Parameter(type = ItemIO.OUTPUT, label = "Skeleton")
+	private ImagePlus skeletonImage;
 	@Parameter
 	private StatusService statusService;
 	@Parameter
@@ -189,6 +198,8 @@ public class IntertrabecularAngleWrapper extends BoneJCommand {
 		statusService.showStatus("Intertrabecular angles: Initialising...");
 		statusService.showStatus("Intertrabecular angles: skeletonising");
 		final ImagePlus skeleton = skeletonise();
+		if (showSkeleton)
+			skeletonImage = skeleton.duplicate();
 		statusService.showStatus("Intertrabecular angles: analysing skeletons");
 		statusService.showProgress(0, PROGRESS_STEPS);
 		final Graph[] graphs = analyzeSkeleton(skeleton);

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/IntertrabecularAngleWrapperTest.java
@@ -291,28 +291,6 @@ public class IntertrabecularAngleWrapperTest extends AbstractWrapperTest {
 
 	}
 
-	/**
-	 * Test that the skeleton is displayed, when the input image gets skeletonised
-	 */
-	@Test
-	public void testSkeletonImageWhenSkeletonised() throws Exception {
-		// SETUP
-		doNothing().when(MOCK_UI).show(any(ImagePlus.class));
-		final ImagePlus square = NewImage.createByteImage("Test", 4, 4, 1,
-			FILL_BLACK);
-		square.getStack().getProcessor(1).set(1, 1, (byte) 0xFF);
-		square.getStack().getProcessor(1).set(1, 2, (byte) 0xFF);
-		square.getStack().getProcessor(1).set(2, 1, (byte) 0xFF);
-		square.getStack().getProcessor(1).set(2, 2, (byte) 0xFF);
-
-		// EXECUTE
-		command().run(IntertrabecularAngleWrapper.class, true, "inputImage",
-			square).get();
-
-		// VERIFY
-		verify(MOCK_UI, timeout(1000)).show(any(ImagePlus.class));
-	}
-
 	@Test
 	public void testTimeDimensionCancelsPlugin() throws Exception {
 		// SETUP


### PR DESCRIPTION
Refactors the output behaviour of the ITA plugin wrapper so that whether a skeleton image is shown is under total control of the user option. Both user option and image output are specified as Parameters conforming to the IJ2 plugin design language. 