### PR TITLE
Set the ImageJ test instance's UI to not headless.

### DIFF
--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/AbstractWrapperTest.java
@@ -96,6 +96,7 @@ public abstract class AbstractWrapperTest {
 
     @Before
     public void setup() {
+    	  imageJ.ui().setHeadless(false);
         imageJ.ui().setDefaultUI(MOCK_UI);
         doNothing().when(MOCK_REPORTER).reportEvent(anyString());
     }


### PR DESCRIPTION
It appears that this `headless` setting is persistent across test classes, so classes must declare what they want (headless or not) before executing test methods.

Fixes #320 