### PR TITLE
Changed method visibility in Ellipsoid

### DIFF
--- a/Legacy/util/src/main/java/org/bonej/geometry/Ellipsoid.java
+++ b/Legacy/util/src/main/java/org/bonej/geometry/Ellipsoid.java
@@ -409,7 +409,7 @@ public class Ellipsoid {
 	 *
 	 * @return array containing minimal and maximal x values
 	 */
-	private double[] getXMinAndMax() {
+	public double[] getXMinAndMax() {
 		final double m11 = ev[0][0] * ra;
 		final double m12 = ev[0][1] * rb;
 		final double m13 = ev[0][2] * rc;


### PR DESCRIPTION
Hi,

This commit just changes the visibility of the getXMinAndMax method in the Ellipsoid class to public, so it matches getYMinAndMax and getZMinAndMax and can be used elsewhere.

Cheers,
Stephen