### PR TITLE
Use the isotropy checker in AxisUtils for calibrating surfaces

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/SurfaceAreaWrapper.java
@@ -139,33 +139,6 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 	}
 
 	/**
-	 * Check if all the spatial axes have a matching calibration, e.g. same unit,
-	 * same scaling.
-	 * <p>
-	 * NB: Public and static for testing purposes.
-	 * </p>
-	 *
-	 * @param space an N-dimensional space.
-	 * @param <T> type of the space
-	 * @return true if all spatial axes have matching calibration. Also returns
-	 *         true if none of them have a unit
-	 */
-	// TODO make into a utility method or remove if mesh area considers
-	// calibration in the future
-	static <T extends AnnotatedSpace<CalibratedAxis>> boolean
-		isAxesMatchingSpatialCalibration(final T space)
-	{
-		final boolean noUnits = spatialAxisStream(space).map(CalibratedAxis::unit)
-			.allMatch(StringUtils::isNullOrEmpty);
-		final boolean matchingUnit = spatialAxisStream(space).map(
-			CalibratedAxis::unit).distinct().count() == 1;
-		final boolean matchingScale = spatialAxisStream(space).map(a -> a
-			.averageScale(0, 1)).distinct().count() == 1;
-
-		return (matchingUnit || noUnits) && matchingScale;
-	}
-
-	/**
 	 * Writes the surface mesh as a binary, little endian STL file
 	 * <p>
 	 * NB: Public and static for testing purposes
@@ -283,7 +256,7 @@ public class SurfaceAreaWrapper<T extends RealType<T> & NativeType<T>> extends B
 	private void prepareResults() {
 		unitHeader = ResultUtils.getUnitHeader(inputImage, unitService, "²");
 
-		if (isAxesMatchingSpatialCalibration(inputImage)) {
+		if (AxisUtils.isSpatialCalibrationsIsotropic(inputImage, 0.001, unitService)) {
 			final double scale = inputImage.axis(0).averageScale(0.0, 1.0);
 			areaScale = scale * scale;
 		}

--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -32,9 +32,7 @@ package org.bonej.wrapperPlugins;
 
 import static org.bonej.wrapperPlugins.SurfaceAreaWrapper.STL_WRITE_ERROR;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -44,7 +42,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.scijava.ui.DialogPrompt.MessageType.ERROR_MESSAGE;
-import static org.scijava.ui.DialogPrompt.MessageType.WARNING_MESSAGE;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -117,101 +114,6 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 		// Verify that write error dialog got shown
 		verify(MOCK_UI, timeout(1000).times(1)).dialogPrompt(startsWith(
 			STL_WRITE_ERROR), anyString(), eq(ERROR_MESSAGE), any());
-	}
-
-	@Test
-	public void testIsAxesMatchingSpatialCalibration() {
-		// Create a test image with uniform calibration
-		final String unit = "mm";
-		final double scale = 0.75;
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, unit, scale);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, unit, scale);
-		final Img<BitType> img = ArrayImgs.bits(1, 1);
-		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis);
-
-		final boolean result = SurfaceAreaWrapper.isAxesMatchingSpatialCalibration(
-			imgPlus);
-
-		assertTrue("Axes should have matching calibration", result);
-	}
-
-	@Test
-	public void testIsAxesMatchingSpatialCalibrationDifferentScales() {
-		// Create a test image with different scales in calibration
-		final String unit = "mm";
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, unit, 0.5);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, unit, 0.6);
-		final Img<BitType> img = ArrayImgs.bits(1, 1);
-		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis);
-
-		final boolean result = SurfaceAreaWrapper.isAxesMatchingSpatialCalibration(
-			imgPlus);
-
-		assertFalse(
-			"Different scales in axes should mean that calibration doesn't match",
-			result);
-	}
-
-	@Test
-	public void testIsAxesMatchingSpatialCalibrationDifferentUnits() {
-		// Create a test image with different units in calibration
-		final double scale = 0.75;
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "cm", scale);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, "mm", scale);
-		final Img<BitType> img = ArrayImgs.bits(1, 1);
-		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis);
-
-		final boolean result = SurfaceAreaWrapper.isAxesMatchingSpatialCalibration(
-			imgPlus);
-
-		assertFalse(
-			"Different units in axes should mean that calibration doesn't match",
-			result);
-	}
-
-	@Test
-	public void testIsAxesMatchingSpatialCalibrationNoUnits() {
-		// Create a test image with no calibration units
-		final double scale = 0.75;
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, "", scale);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, null, scale);
-		final Img<BitType> img = ArrayImgs.bits(1, 1);
-		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis);
-
-		final boolean result = SurfaceAreaWrapper.isAxesMatchingSpatialCalibration(
-			imgPlus);
-
-		assertTrue("No units should mean matching calibration", result);
-	}
-
-	@Test
-	public void testMismatchingCalibrationsShowsWarningDialog() throws Exception {
-		// Create a test image with different scales in spatial calibration
-		final String unit = "mm";
-		final DefaultLinearAxis xAxis = new DefaultLinearAxis(Axes.X, unit, 0.5);
-		final DefaultLinearAxis yAxis = new DefaultLinearAxis(Axes.Y, unit, 0.6);
-		final DefaultLinearAxis zAxis = new DefaultLinearAxis(Axes.Z, unit, 0.6);
-		final DefaultLinearAxis tAxis = new DefaultLinearAxis(Axes.TIME);
-		final Img<BitType> img = ArrayImgs.bits(1, 1, 1, 1);
-		final ImgPlus<BitType> imgPlus = new ImgPlus<>(img, "Test image", xAxis,
-			yAxis, zAxis, tAxis);
-
-		// Mock UI
-		final SwingDialogPrompt mockPrompt = mock(SwingDialogPrompt.class);
-		when(MOCK_UI.dialogPrompt(eq(SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(
-			WARNING_MESSAGE), any())).thenReturn(mockPrompt);
-
-		// Run plugin
-		command().run(SurfaceAreaWrapper.class, true, "inputImage", imgPlus,
-			"exportSTL", false).get();
-
-		// Verify that warning dialog about result scaling got shown once
-		verify(MOCK_UI, timeout(1000).times(1)).dialogPrompt(eq(
-			SurfaceAreaWrapper.BAD_SCALING), anyString(), eq(WARNING_MESSAGE), any());
 	}
 
 	@Test


### PR DESCRIPTION
The axis checker in Surface Area is redundant because the same functionality is provided in AxisUtils.

Fixes #324 