### PR TITLE
SurfaceAreaWrapperTest: update to include the stlDirectory Parameter

### DIFF
--- a/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
+++ b/Modern/wrapperPlugins/src/test/java/org/bonej/wrapperPlugins/SurfaceAreaWrapperTest.java
@@ -172,7 +172,7 @@ public class SurfaceAreaWrapperTest extends AbstractWrapperTest {
 
 		// EXECUTE
 		final CommandModule module = command().run(SurfaceAreaWrapper.class,
-			true, "inputImage", imgPlus, "exportSTL", false).get();
+			true, "inputImage", imgPlus, "exportSTL", false, "stlDirectory", "./").get();
 
 		// VERIFY
 		@SuppressWarnings("unchecked")


### PR DESCRIPTION
Need to remember to run `mvn test -P allTests` before merging to `master`...
This PR fixes a failing test. Maven complains:
```
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.547 s <<< FAILURE! - in org.bonej.wrapperPlugins.SurfaceAreaWrapperTest
[ERROR] testResults(org.bonej.wrapperPlugins.SurfaceAreaWrapperTest)  Time elapsed: 0.03 s  <<< FAILURE!
java.lang.AssertionError
	at org.bonej.wrapperPlugins.SurfaceAreaWrapperTest.testResults(SurfaceAreaWrapperTest.java:181)
```