### PR TITLE
Set thickness threshold based on input range

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -207,6 +207,7 @@ public class ThicknessWrapper extends BoneJCommand {
 		this.foreground = foreground;
 		final String suffix = foreground ? "_Tb.Th" : "_Tb.Sp";
 		localThickness.setTitleSuffix(suffix);
+		localThickness.threshold = (int) (inputImage.getStatistics().max + 1) / 2;
 		localThickness.inverse = !foreground;
 	}
 

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -39,6 +39,7 @@ import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 import static org.bonej.wrapperPlugins.wrapperUtils.Common.cancelMacroSafe;
 
 import ij.ImagePlus;
+import ij.process.ImageStatistics;
 import ij.process.LUT;
 import ij.process.StackStatistics;
 
@@ -207,7 +208,8 @@ public class ThicknessWrapper extends BoneJCommand {
 		this.foreground = foreground;
 		final String suffix = foreground ? "_Tb.Th" : "_Tb.Sp";
 		localThickness.setTitleSuffix(suffix);
-		localThickness.threshold = (int) (inputImage.getStatistics().max + 1) / 2;
+		ImageStatistics stats = inputImage.getStatistics();
+		localThickness.threshold = (int) (stats.min + stats.max + 1) / 2;
 		localThickness.inverse = !foreground;
 	}
 


### PR DESCRIPTION
Ran into this issue working on a [new napari-imagej use case](https://github.com/imagej/napari-imagej/pull/240)

[`ThicknessWrapper`](https://github.com/bonej-org/BoneJ2/blob/2683c50e8990a6deb767f3c954445fcee52e942e/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java#L234) ensures that the input image is binary, but it makes the assumption on a threshold which may not make sense based on the input image's unique values.

This PR adjusts the threshold when running the plugin, such that the threshold is halfway between the two unique values.