### PR TITLE
Revert "Set thickness threshold based on input range"

### DIFF
--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -39,7 +39,6 @@ import static org.bonej.wrapperPlugins.CommonMessages.NO_IMAGE_OPEN;
 import static org.bonej.wrapperPlugins.wrapperUtils.Common.cancelMacroSafe;
 
 import ij.ImagePlus;
-import ij.process.ImageStatistics;
 import ij.process.LUT;
 import ij.process.StackStatistics;
 
@@ -208,8 +207,6 @@ public class ThicknessWrapper extends BoneJCommand {
 		this.foreground = foreground;
 		final String suffix = foreground ? "_Tb.Th" : "_Tb.Sp";
 		localThickness.setTitleSuffix(suffix);
-		ImageStatistics stats = inputImage.getStatistics();
-		localThickness.threshold = (int) (stats.min + stats.max + 1) / 2;
 		localThickness.inverse = !foreground;
 	}
 


### PR DESCRIPTION
Reverts bonej-org/BoneJ2#332

Thanks for the contribution @gselzer and sorry to have to revert this one.

For many years we have been communicating with BoneJ users that 0 is background ("marrow space") and 255 is foreground ("bone tissue"), so implementing a change where this ImageJ-wide convention is not strictly followed breaks this assumption. The expected user behaviour is to do the image segmentation (binarisation) first, into a [0,255] image, then run all the subsequent operations on that image. In this way consistency of the pixels used in the different analyses is maintained without having to copy over the threshold value between plugins, or to implement the same interpolation routine that you have suggested here in all the plugins. If a user's image is logically binary in some other way (e.g. 0 and 1), it is up to them to make it into a binary image that satisfies the 0 and 255 convention (e.g. by multiplying by 255, inverting, etc.).