### PR TITLE
Fix negative Conn.D due to int overflow

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -155,7 +155,7 @@ public class Connectivity implements PlugIn {
 		final double vW = cal.pixelWidth;
 		final double vH = cal.pixelHeight;
 		final double vD = cal.pixelDepth;
-		final double stackVolume = width * height * depth * vW * vH * vD;
+		final double stackVolume = (double) width * (double) height * depth * vW * vH * vD;
 		final double connDensity = connectivity / stackVolume;
 		return connDensity;
 	}

--- a/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
+++ b/Modern/wrapperPlugins/src/main/java/org/bonej/wrapperPlugins/ThicknessWrapper.java
@@ -82,7 +82,7 @@ public class ThicknessWrapper extends BoneJCommand {
 	@Parameter(label = "Calculate:",
 		description = "Which thickness measures to calculate",
 		style = ChoiceWidget.RADIO_BUTTON_VERTICAL_STYLE, choices = {
-			"Trabecular thickness", "Trabecular spacing", "Both" })
+			"Trabecular thickness", "Trabecular separation", "Both" })
 	private String mapChoice = "Trabecular thickness";
 
 	@Parameter(label = "Show thickness maps",
@@ -98,8 +98,8 @@ public class ThicknessWrapper extends BoneJCommand {
 	@Parameter(label = "Trabecular thickness", type = ItemIO.OUTPUT)
 	private ImagePlus trabecularMap;
 
-	@Parameter(label = "Trabecular spacing", type = ItemIO.OUTPUT)
-	private ImagePlus spacingMap;
+	@Parameter(label = "Trabecular separation", type = ItemIO.OUTPUT)
+	private ImagePlus separationMap;
 
 	@Parameter
 	private UIService uiService;
@@ -134,11 +134,11 @@ public class ThicknessWrapper extends BoneJCommand {
 				trabecularMap.setDisplayRange(0.0, trabecularStats.max);
 				trabecularMap.setLut(fire);	
 			}
-			spacingMap = thicknessMaps.get(false);
-			if (spacingMap != null) {
-				final StackStatistics spacingStats = new StackStatistics(spacingMap);
-				spacingMap.setDisplayRange(0.0, spacingStats.max);
-				spacingMap.setLut(fire);
+			separationMap = thicknessMaps.get(false);
+			if (separationMap != null) {
+				final StackStatistics separationStats = new StackStatistics(separationMap);
+				separationMap.setDisplayRange(0.0, separationStats.max);
+				separationMap.setLut(fire);
 			}
 		}
 		reportUsage();
@@ -190,7 +190,7 @@ public class ThicknessWrapper extends BoneJCommand {
 		if ("Trabecular thickness".equals(mapChoice)) {
 			mapOptions.add(true);
 		}
-		else if ("Trabecular spacing".equals(mapChoice)) {
+		else if ("Trabecular separation".equals(mapChoice)) {
 			mapOptions.add(false);
 		}
 		else if ("Both".equals(mapChoice)) {


### PR DESCRIPTION
Multiplying image width × height × depth can easily overflow `Integer.MAX_VALUE` when image stack dimensions exceed about 1300 pixels in each direction.

The result is that the `int` overflows and goes negative and stack volume appears negative (which is physically impossible in this universe so should be a huge red flag to anyone seeing negative Conn.D). The fix is a simple cast to `long`.