### PR TITLE
Fix an int overflow caused by int multiplications

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -155,7 +155,7 @@ public class Connectivity implements PlugIn {
 		final double vW = cal.pixelWidth;
 		final double vH = cal.pixelHeight;
 		final double vD = cal.pixelDepth;
-		final double stackVolume = width * height * depth * vW * vH * vD;
+		final double stackVolume = (long) width * (long) height * depth * vW * vH * vD;
 		final double connDensity = connectivity / stackVolume;
 		return connDensity;
 	}


### PR DESCRIPTION
Maths as written are processed as ints meaning it overflows before getting to the doubles. Casting to long at the beginning fixes it.

The result was that for images with side lengths > 1300 pixels, Conn.D would be reported as negative, which is physically impossible because it implies a negative volume that cannot exist in this universe, when Connectivity itself is positive.