### PR TITLE
Use dedicated 3-way sort

### DIFF
--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategy.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/EllipsoidOptimisationStrategy.java
@@ -91,16 +91,14 @@ public class EllipsoidOptimisationStrategy extends AbstractBinaryFunctionOp<byte
 
 		for (int i = 0; i < contactPoints.size(); i++) {
 			final double[] p = contactPoints.get(i);
-			final double px = p[0];
-			final double py = p[1];
-			final double pz = p[2];
+			final double px = p[0] - cx;
+			final double py = p[1] - cy;
+			final double pz = p[2] - cz;
 
-			Vector3d distance = new Vector3d(px, py, pz);
-			distance.sub(new Vector3d(cx, cy, cz));
-			final double l = distance.length();
-			final double x = (px - cx) / l;
-			final double y = (py - cy) / l;
-			final double z = (pz - cz) / l;
+			final double l = Math.sqrt(px * px + py * py + pz * pz);
+			final double x = px / l;
+			final double y = py / l;
+			final double z = pz / l;
 			final double[] u = {x, y, z};
 			unitVectors[i] = u;
 		}

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
@@ -185,7 +185,8 @@ public class QuickEllipsoid {
 		final double vy = y - cy;
 		final double vz = z - cz;
 
-		final double maxRadius = Math.max(ra, Math.max(rb, rc));
+		final double[] radii = getSortedRadii();
+		final double maxRadius = radii[2];
 
 		// if further than maximal sphere's bounding box, must be outside
 		if (Math.abs(vx) > maxRadius || Math.abs(vy) > maxRadius || Math.abs(vz) > maxRadius)
@@ -201,7 +202,7 @@ public class QuickEllipsoid {
 
 		// if length closer than minor semiaxis length
 		// must be inside
-		final double minRadius = Math.min(ra, Math.min(rb, rc));
+		final double minRadius = radii[0];
 		if (length <= minRadius)
 			return true;
 

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
@@ -185,8 +185,7 @@ public class QuickEllipsoid {
 		final double vy = y - cy;
 		final double vz = z - cz;
 
-		final double[] radii = getSortedRadii();
-		final double maxRadius = radii[2];
+		final double maxRadius = Math.max(ra, Math.max(rb, rc));
 
 		// if further than maximal sphere's bounding box, must be outside
 		if (Math.abs(vx) > maxRadius || Math.abs(vy) > maxRadius || Math.abs(vz) > maxRadius)
@@ -202,7 +201,8 @@ public class QuickEllipsoid {
 
 		// if length closer than minor semiaxis length
 		// must be inside
-		if (length <= radii[0])
+		final double minRadius = Math.min(ra, Math.min(rb, rc));
+		if (length <= minRadius)
 			return true;
 
 		final double[][] h = getEllipsoidTensor();

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
@@ -316,8 +316,29 @@ public class QuickEllipsoid {
 	 * @return radii in ascending order
 	 */
 	public double[] getSortedRadii() {
-		final double[] sortedRadii = {ra, rb, rc};
-		Arrays.sort(sortedRadii);
+		double a = this.ra;
+		double b = this.rb;
+		double c = this.rc;
+		double temp = 0;
+
+		if (a > b) {
+			temp = a;
+			a = b;
+			b = temp;
+		}
+		if (b > c) {
+			temp = b;
+			b = c;
+			c = temp;
+		}
+		if (a > b) {
+			temp = a;
+			a = b;
+			b = temp;
+		}
+
+		final double[] sortedRadii = { a, b, c };
+
 		return sortedRadii;
 	}
 

--- a/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
+++ b/Modern/ops/src/main/java/org/bonej/ops/ellipsoid/QuickEllipsoid.java
@@ -367,15 +367,15 @@ public class QuickEllipsoid {
 		refreshRandomNumbersIfNeeded();
 
 		final double[] sortedRadii = getSortedRadii();
-		final double muMax = sortedRadii[1]* sortedRadii[2];
+		final double muMax = sortedRadii[1] * sortedRadii[2];
 		final double[][] surfacePoints = new double[n][3];
 		int surfacePointsFound = 0;
 		int attemptCounter = 0;
-		while (surfacePointsFound<n) {
-			final double[] v =  (attemptCounter<numberOfPreallocatedRandomNumbers)? sphereRandomVectors[attemptCounter] : sphereRng.nextVector();
+		while (surfacePointsFound < n) {
+			final double[] v =  (attemptCounter < numberOfPreallocatedRandomNumbers)? sphereRandomVectors[attemptCounter] : sphereRng.nextVector();
 			final double mu = getMu(v);
-			double rn = (attemptCounter<numberOfPreallocatedRandomNumbers) ? uniformRandomNumbers[attemptCounter] : rng.nextDouble();
-			if(rn<=mu/muMax) {
+			double rn = (attemptCounter < numberOfPreallocatedRandomNumbers) ? uniformRandomNumbers[attemptCounter] : rng.nextDouble();
+			if(rn <= mu / muMax) {
 				surfacePoints[surfacePointsFound] = new double[]{v[0], v[1], v[2]};
 				surfacePointsFound++;
 			}
@@ -385,15 +385,15 @@ public class QuickEllipsoid {
 	}
 
 	private void refreshRandomNumbersIfNeeded() {
-		if(sphereRandomVectors==null)
+		if(sphereRandomVectors == null)
 		{
 			sphereRandomVectors = new double[numberOfPreallocatedRandomNumbers][3];
 			uniformRandomNumbers = new double[numberOfPreallocatedRandomNumbers];
 		}
 
-		if((lastRefreshed % randomNumberRefreshmentPeriodicity)==0)
+		if((lastRefreshed % randomNumberRefreshmentPeriodicity) == 0)
 		{
-			for(int i=0;i<numberOfPreallocatedRandomNumbers;i++)
+			for(int i = 0; i < numberOfPreallocatedRandomNumbers; i++)
 			{
 				sphereRandomVectors[i] = sphereRng.nextVector();
 				uniformRandomNumbers[i] = rng.nextDouble();
@@ -403,10 +403,10 @@ public class QuickEllipsoid {
 	}
 
 	private double getMu(final double[] v) {
-		final double ra2 = ra*ra;
-		final double rb2 = rb*rb;
-		final double rc2 = rc*rc;
-		final double sqSum = ra2*rc2*v[0]*v[0]+ra2*rb2*v[2]*v[2]+rb2*rc2*v[0]*v[0];
+		final double ra2 = ra * ra;
+		final double rb2 = rb * rb;
+		final double rc2 = rc * rc;
+		final double sqSum = ra2 * rc2 * v[0] * v[0] + ra2 * rb2 * v[2] * v[2] + rb2 * rc2 * v[0] * v[0];
 		return Math.sqrt(sqSum);
 	}
 

--- a/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuickEllipsoidTest.java
+++ b/Modern/ops/src/test/java/org/bonej/ops/ellipsoid/QuickEllipsoidTest.java
@@ -32,6 +32,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.Random;
+
 public class QuickEllipsoidTest {
     /**
      * Test for {@link QuickEllipsoid#getSurfacePoints(double[][])}
@@ -98,5 +101,20 @@ public class QuickEllipsoidTest {
         QuickEllipsoid e = new QuickEllipsoid(new double[]{1,2,3}, new double[]{1,1,1},new double[][]{{1,0,0},{0,1,0},{0,0,1}});
         assertFalse(e.contains(1,4,1));
         assertTrue(e.contains(1,1,2));
+    }
+    
+    @Test
+    public void testGetSortedRadii() {
+    	Random rand = new Random();
+    	for (int i = 0; i < 1000; i++) {
+    		final double a = rand.nextDouble();
+    		final double b = rand.nextDouble();
+    		final double c = rand.nextDouble();
+    		final double[] radii = {a, b, c};
+    		final double[] sortedRadii = {a , b, c};
+    		Arrays.sort(sortedRadii);
+    		QuickEllipsoid e = new QuickEllipsoid(radii, new double[]{1,1,1}, new double[][]{{1,0,0},{0,1,0},{0,0,1}});
+    		assertArrayEquals(sortedRadii, e.getSortedRadii(), 0);
+    	}
     }
 }


### PR DESCRIPTION
`Arrays.sort()` carries overhead because it's generalised. But we know precisely the case here, which is always a 3-element array. Profiling shows that while assigning ellipsoid IDs most (98% !) of the time is spent in `getSortedRadii()`. This dedicated 3-way sort is about 2× faster than Arrays.sort in a basic performance test.

```
Arrays.sort took 76.890026 ms for 1000000 iterations
ThreeWay took 34.917113 ms for 1000000 iterations
```

```java
import java.util.Arrays;
import java.util.Random;

public class ThreeWaySortPerformance {
	public static void main(String[] args) {
		final Random rand = new Random();
		final int nTrials = (int) 1E6;
		final double[] radii = new double[3];
		
		long start = System.nanoTime();
		long end = System.nanoTime();
		long cumulativeTime = 0;
		
		for (int i = 0; i < nTrials; i++) {
			radii[0] = rand.nextDouble();
			radii[1] = rand.nextDouble();
			radii[2] = rand.nextDouble();
			start = System.nanoTime();
			Arrays.sort(radii);
			end = System.nanoTime();
			cumulativeTime += end - start;
		}
		
		double duration = cumulativeTime / 1E6;
		
		System.out.println("Arrays.sort took " + duration + " ms for " + nTrials + " iterations");
		
		cumulativeTime = 0;
		
		for (int i = 0; i < nTrials; i++) {
			double a = rand.nextDouble();
			double b = rand.nextDouble();
			double c = rand.nextDouble();		
			double temp = 0;

			start = System.nanoTime();
			if (a > b) {
				temp = a;
				a = b;
				b = temp;
			}
			if (b > c) {
				temp = b;
				b = c;
				c = temp;
			}
			if (a > b) {
				temp = a;
				a = b;
				b = temp;
			}

			final double[] sortedRadii = { a, b, c };
			end = System.nanoTime();
			cumulativeTime += end - start;
		}
		
		duration = cumulativeTime / 1E6;
		
		System.out.println("ThreeWay took " + duration + " ms for " + nTrials + " iterations");		
	}
}
```