### PR TITLE
Use bonej-plus-0.0.6

### DIFF
--- a/Modern/wrapperPlugins/pom.xml
+++ b/Modern/wrapperPlugins/pom.xml
@@ -119,17 +119,15 @@
         <dependency>
             <groupId>org.bonej</groupId>
             <artifactId>bonej-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bonej</groupId>
             <artifactId>bonej-ops</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
         	<groupId>org.bonej</groupId>
         	<artifactId>bonej-plus</artifactId>
-        	<version>0.0.5</version>
+        	<version>0.0.6</version>
         </dependency>
 
         <!-- ImageJ dependencies -->


### PR DESCRIPTION
bonej-plus release versions are now available [at maven.scijava.org](https://maven.scijava.org/#nexus-search;gav~org.bonej~bonej-plus~~~). The github packages repository is retained in case there's a need to get snapshot versions remotely, however, it might not be needed long-term if scijava works out. 