### PR TITLE
Don't send snapshots to scijava Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,8 @@
         <repository>
             <id>scijava.public</id>
             <url>https://maven.scijava.org/content/groups/public</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
         </repository>
         <repository>
             <id>github</id>


### PR DESCRIPTION
Send only releases and not snapshots to scijava Maven repository.