### PR TITLE
XamFlow integration

### DIFF
--- a/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
@@ -7,14 +7,15 @@ import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.ShortType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.type.numeric.RealType;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -212,143 +213,208 @@ public final class DatasetUtil {
 
 		boolean fastPathUsed = false;
 
-		// --- Fast Path: Use ArrayDataAccess to get the backing array ---
-		if (img instanceof ArrayImg && img instanceof ArrayDataAccess) {
+		System.out.println("img class = " + img.getClass().getName());
+		long start = System.nanoTime();
+		long end = start;
+		if (img instanceof ArrayImg) {
+			System.out.println("Using fast path for Dataset-> RAW");
 			try (FileOutputStream fos = new FileOutputStream(outputFile)) {
-				ArrayDataAccess<?> access = (ArrayDataAccess<?>) img;
-				Object storage = access.getCurrentStorageArray();
 
-				if (storage instanceof byte[]) {
-					fos.write((byte[]) storage);
+				ArrayImg<?, ?> arrayImg = (ArrayImg<?, ?>) img;
+				Object access = arrayImg.update(null);
+				System.out.println("access class = " + access.getClass().getName());
+
+				if (access instanceof ByteArray) {
+					fos.write(((ByteArray) access).getCurrentStorageArray());
 					fastPathUsed = true;
-				} else if (storage instanceof short[]) {
-					short[] shorts = (short[]) storage;
-					ByteBuffer buffer = ByteBuffer.allocate(shorts.length * 2)
-							.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+				}
+				else if (access instanceof ShortArray) {
+
+					short[] shorts =
+							((ShortArray) access).getCurrentStorageArray();
+
+					ByteBuffer buffer =
+							ByteBuffer.allocate(shorts.length * 2)
+							.order(littleEndian
+									? ByteOrder.LITTLE_ENDIAN
+											: ByteOrder.BIG_ENDIAN);
+
 					buffer.asShortBuffer().put(shorts);
+
 					fos.write(buffer.array());
 					fastPathUsed = true;
-				} else if (storage instanceof float[]) {
-					float[] floats = (float[]) storage;
-					ByteBuffer buffer = ByteBuffer.allocate(floats.length * 4)
-							.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+				}
+				else if (access instanceof FloatArray) {
+
+					float[] floats =
+							((FloatArray) access).getCurrentStorageArray();
+
+					ByteBuffer buffer =
+							ByteBuffer.allocate(floats.length * 4)
+							.order(littleEndian
+									? ByteOrder.LITTLE_ENDIAN
+											: ByteOrder.BIG_ENDIAN);
+
 					buffer.asFloatBuffer().put(floats);
+
 					fos.write(buffer.array());
 					fastPathUsed = true;
 				}
 			}
+			end = System.nanoTime();
 		}
 
 		// --- Fallback: Cursor Iteration (if not an ArrayImg or access failed) ---
 		if (!fastPathUsed) {
+			System.out.println("Writing Dataset to RAW using the slow path");
 			try (FileOutputStream fos = new FileOutputStream(outputFile)) {
 				fallbackCursorWrite(fos, img, bytesPerPixel, littleEndian);
 			}
+			end = System.nanoTime();
 		}
+		System.out.println("RAW file written in "+(long)((end - start) / 1E6)+" ms");
 	}
 
 	/**
 	 * Fallback method for non-array images.
 	 * Iterates pixels and writes them sequentially.
+	 * Type checking is performed once before iteration for efficiency.
 	 */
-	private static void fallbackCursorWrite(OutputStream fos, 
-			RandomAccessibleInterval<?> img, 
-			int bytesPerPixel, 
+	private static void fallbackCursorWrite(OutputStream fos,
+			RandomAccessibleInterval<?> img,
+			int bytesPerPixel,
 			boolean littleEndian) throws IOException {
 
-		int batchSize = 65536 / bytesPerPixel; 
+		int batchSize = 65536 / bytesPerPixel;
 		if (batchSize < 1) batchSize = 1;
 		byte[] batchBuffer = new byte[batchSize * bytesPerPixel];
+
+		// Determine the pixel type ONCE before iterating
+		Object typeSample = img.firstElement();
+
+		if (typeSample instanceof UnsignedByteType || typeSample instanceof ByteType) {
+			write8Bit(fos, img, batchBuffer);
+		} else if (typeSample instanceof UnsignedShortType) {
+			write16BitUnsigned(fos, img, batchBuffer, littleEndian);
+		} else if (typeSample instanceof ShortType) {
+			write16BitSigned(fos, img, batchBuffer, littleEndian);
+		} else if (typeSample instanceof FloatType) {
+			write32BitFloat(fos, img, batchBuffer, littleEndian);
+		} else {
+			throw new UnsupportedOperationException(
+					"Unsupported pixel type in cursor fallback: " + typeSample.getClass().getSimpleName());
+		}
+	}
+
+	private static void write8Bit(OutputStream fos, RandomAccessibleInterval<?> img, byte[] batchBuffer)
+			throws IOException {
+
+		@SuppressWarnings("unchecked")
+		var cursor = ((RandomAccessibleInterval<IntegerType<?>>) img).cursor();
 		int batchCount = 0;
 
-		// Cursor does NOT implement AutoCloseable
-		var cursor = img.cursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			batchBuffer[batchCount++] = (byte) (cursor.get().getIntegerLong() & 0xFF);
 
-		try {
-			while (cursor.hasNext()) {
-				cursor.fwd();
-				Object pixelObj = cursor.get();
-
-				if (bytesPerPixel == 1) {
-					// For 8-bit, we need an integer value between 0-255 (or -128 to 127)
-					// Use getLong() from IntegerType which handles both signed/unsigned
-					long val = -1;
-
-					if (pixelObj instanceof IntegerType<?>) {
-						val = ((IntegerType<?>) pixelObj).getIntegerLong();
-						// Mask to ensure we get the lower 8 bits correctly for unsigned display if needed
-						// But usually raw writes just want the bits.
-						batchBuffer[batchCount++] = (byte) (val & 0xFF);
-					} else if (pixelObj instanceof RealType<?>) {
-						double dVal = ((RealType<?>) pixelObj).getRealDouble();
-						batchBuffer[batchCount++] = (byte) ((int) dVal & 0xFF);
-					} else {
-						throw new IllegalStateException("Unknown pixel type for 8-bit conversion");
-					}
-
-				} else if (bytesPerPixel == 2) {
-					// 16-bit short
-					long val = -1;
-					if (pixelObj instanceof IntegerType<?>) {
-						val = ((IntegerType<?>) pixelObj).getIntegerLong();
-					} else if (pixelObj instanceof RealType<?>) {
-						double dVal = ((RealType<?>) pixelObj).getRealDouble();
-						val = (long) dVal;
-					} else {
-						throw new IllegalStateException("Unknown pixel type for 16-bit conversion");
-					}
-
-					// Ensure we treat it as unsigned 16-bit for writing? 
-					// Actually, we just write the bits.
-					int iv = (int) (val & 0xFFFF);
-
-					if (littleEndian) {
-						batchBuffer[batchCount++] = (byte) (iv & 0xFF);
-						batchBuffer[batchCount++] = (byte) ((iv >> 8) & 0xFF);
-					} else {
-						batchBuffer[batchCount++] = (byte) ((iv >> 8) & 0xFF);
-						batchBuffer[batchCount++] = (byte) (iv & 0xFF);
-					}
-
-				} else if (bytesPerPixel == 4) {
-					// 32-bit float
-					float fVal = 0f;
-					if (pixelObj instanceof FloatType) {
-						fVal = ((FloatType) pixelObj).get();
-					} else if (pixelObj instanceof RealType<?>) {
-						fVal = (float) ((RealType<?>) pixelObj).getRealDouble();
-					} else if (pixelObj instanceof IntegerType<?>) {
-						fVal = ((IntegerType<?>) pixelObj).getIntegerLong();
-					} else {
-						throw new IllegalStateException("Unknown pixel type for 32-bit conversion");
-					}
-
-					int bits = Float.floatToIntBits(fVal);
-					if (littleEndian) {
-						batchBuffer[batchCount++] = (byte) (bits);
-						batchBuffer[batchCount++] = (byte) (bits >> 8);
-						batchBuffer[batchCount++] = (byte) (bits >> 16);
-						batchBuffer[batchCount++] = (byte) (bits >> 24);
-					} else {
-						batchBuffer[batchCount++] = (byte) (bits >> 24);
-						batchBuffer[batchCount++] = (byte) (bits >> 16);
-						batchBuffer[batchCount++] = (byte) (bits >> 8);
-						batchBuffer[batchCount++] = (byte) (bits);
-					}
-				}
-
-				if (batchCount >= batchBuffer.length) {
-					fos.write(batchBuffer, 0, batchCount);
-					batchCount = 0;
-				}
-			}
-
-			if (batchCount > 0) {
+			if (batchCount >= batchBuffer.length) {
 				fos.write(batchBuffer, 0, batchCount);
+				batchCount = 0;
 			}
-		} finally {
-			// No explicit close needed for Cursor
-			cursor = null;
+		}
+		if (batchCount > 0) {
+			fos.write(batchBuffer, 0, batchCount);
+		}
+	}
+
+	private static void write16BitUnsigned(OutputStream fos, RandomAccessibleInterval<?> img,
+			byte[] batchBuffer, boolean littleEndian) throws IOException {
+
+		@SuppressWarnings("unchecked")
+		var cursor = ((RandomAccessibleInterval<UnsignedShortType>) img).cursor();
+		int batchCount = 0;
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			int val = cursor.get().get();
+
+			if (littleEndian) {
+				batchBuffer[batchCount++] = (byte) (val & 0xFF);
+				batchBuffer[batchCount++] = (byte) ((val >> 8) & 0xFF);
+			} else {
+				batchBuffer[batchCount++] = (byte) ((val >> 8) & 0xFF);
+				batchBuffer[batchCount++] = (byte) (val & 0xFF);
+			}
+
+			if (batchCount >= batchBuffer.length) {
+				fos.write(batchBuffer, 0, batchCount);
+				batchCount = 0;
+			}
+		}
+		if (batchCount > 0) {
+			fos.write(batchBuffer, 0, batchCount);
+		}
+	}
+
+	private static void write16BitSigned(OutputStream fos, RandomAccessibleInterval<?> img,
+			byte[] batchBuffer, boolean littleEndian) throws IOException {
+
+		@SuppressWarnings("unchecked")
+		var cursor = ((RandomAccessibleInterval<ShortType>) img).cursor();
+		int batchCount = 0;
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			int val = cursor.get().get() & 0xFFFF; // Preserve bit pattern
+
+			if (littleEndian) {
+				batchBuffer[batchCount++] = (byte) (val & 0xFF);
+				batchBuffer[batchCount++] = (byte) ((val >> 8) & 0xFF);
+			} else {
+				batchBuffer[batchCount++] = (byte) ((val >> 8) & 0xFF);
+				batchBuffer[batchCount++] = (byte) (val & 0xFF);
+			}
+
+			if (batchCount >= batchBuffer.length) {
+				fos.write(batchBuffer, 0, batchCount);
+				batchCount = 0;
+			}
+		}
+		if (batchCount > 0) {
+			fos.write(batchBuffer, 0, batchCount);
+		}
+	}
+
+	private static void write32BitFloat(OutputStream fos, RandomAccessibleInterval<?> img,
+			byte[] batchBuffer, boolean littleEndian) throws IOException {
+
+		@SuppressWarnings("unchecked")
+		var cursor = ((RandomAccessibleInterval<FloatType>) img).cursor();
+		int batchCount = 0;
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			int bits = Float.floatToIntBits(cursor.get().get());
+
+			if (littleEndian) {
+				batchBuffer[batchCount++] = (byte) (bits);
+				batchBuffer[batchCount++] = (byte) (bits >> 8);
+				batchBuffer[batchCount++] = (byte) (bits >> 16);
+				batchBuffer[batchCount++] = (byte) (bits >> 24);
+			} else {
+				batchBuffer[batchCount++] = (byte) (bits >> 24);
+				batchBuffer[batchCount++] = (byte) (bits >> 16);
+				batchBuffer[batchCount++] = (byte) (bits >> 8);
+				batchBuffer[batchCount++] = (byte) (bits);
+			}
+
+			if (batchCount >= batchBuffer.length) {
+				fos.write(batchBuffer, 0, batchCount);
+				batchCount = 0;
+			}
+		}
+		if (batchCount > 0) {
+			fos.write(batchBuffer, 0, batchCount);
 		}
 	}
 

--- a/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
@@ -4,178 +4,355 @@ import net.imagej.Dataset;
 import net.imagej.DatasetService;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
-
-import org.scijava.ItemIO;
-import org.scijava.command.Command;
-import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
-import org.scijava.ui.UIService;
-
-import io.scif.services.DatasetIOService;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.type.numeric.RealType;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-@Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Load Raw 3D Image")
-public class DatasetUtil implements Command {
+/**
+ * Utility class for loading raw binary 3D image data into ImageJ2 Datasets.
+ */
+public final class DatasetUtil {
 
-    @Parameter(label = "File Path", required = true, style = "file")
-    private File filePath;
-    
-    @Parameter(type = ItemIO.OUTPUT)
-    private Dataset dataset;
+	private DatasetUtil() {
+		// Prevent instantiation
+	}
 
-    @Parameter(label = "Header Offset (bytes)", min = "0")
-    private long headerOffset = 0;
+	/**
+	 * Loads a raw binary file as a 3D Dataset with spatial calibration.
+	 *
+	 * @param filePath      Path to the raw file on disk
+	 * @param headerOffset  Number of bytes to skip at the start of the file
+	 * @param width         Image width (X dimension)
+	 * @param height        Image height (Y dimension)
+	 * @param depth         Image depth (Z dimension)
+	 * @param pixelType     One of: "uint8", "uint16", "int16", "float32"
+	 * @param byteOrder     One of: "Little-endian", "Big-endian"
+	 * @param spacingX      Voxel spacing in X (mm)
+	 * @param spacingY      Voxel spacing in Y (mm)
+	 * @param spacingZ      Voxel spacing in Z (mm)
+	 * @param datasetService The DatasetService for creating the Dataset
+	 * @return A calibrated 3D Dataset
+	 * @throws IOException if the file cannot be read or is too small
+	 * @throws IllegalArgumentException if parameters are invalid
+	 */
+	public static Dataset loadRaw3D(
+			File filePath,
+			long headerOffset,
+			int width,
+			int height,
+			int depth,
+			String pixelType,
+			String byteOrder,
+			double spacingX,
+			double spacingY,
+			double spacingZ,
+			DatasetService datasetService) throws IOException {
 
-    @Parameter(label = "Width (X)", required = true, min = "1")
-    private int width;
+		// --- Validate ---
+		if (width <= 0 || height <= 0 || depth <= 0) {
+			throw new IllegalArgumentException("Dimensions must be positive integers.");
+		}
+		if (filePath == null || !filePath.exists()) {
+			throw new IllegalArgumentException("File does not exist: " + filePath);
+		}
 
-    @Parameter(label = "Height (Y)", required = true, min = "1")
-    private int height;
+		String pt = pixelType.toLowerCase();
+		int bytesPerPixel;
+		switch (pt) {
+		case "uint8":   bytesPerPixel = 1; break;
+		case "uint16":  bytesPerPixel = 2; break;
+		case "int16":   bytesPerPixel = 2; break;
+		case "float32": bytesPerPixel = 4; break;
+		default:
+			throw new IllegalArgumentException("Unsupported pixel type: " + pixelType);
+		}
 
-    @Parameter(label = "Depth (Z)", required = true, min = "1")
-    private int depth;
+		long totalPixels = (long) width * height * depth;
+		long expectedDataBytes = totalPixels * bytesPerPixel;
+		long expectedTotalBytes = headerOffset + expectedDataBytes;
 
-    @Parameter(label = "Pixel Type", choices = {"uint8", "uint16", "int16", "float32"}, required = true)
-    private String pixelTypeStr;
+		long actualSize = filePath.length();
+		if (actualSize < expectedTotalBytes) {
+			throw new IOException(String.format(
+					"File too small: %d bytes available, but %d needed (offset=%d + data=%d).",
+					actualSize, expectedTotalBytes, headerOffset, expectedDataBytes));
+		}
 
-    // NEW: Explicit byte order selection
-    @Parameter(label = "Byte Order", choices = {"Little-endian", "Big-endian"}, required = true)
-    private String byteOrderStr;
+		// --- Read raw bytes, skipping header ---
+		byte[] rawData = readRawBytes(filePath, headerOffset, (int) expectedDataBytes);
 
-    @Parameter(label = "Spacing X (mm)", stepSize = "0.00001")
-    private double spacingX = 1.0;
+		// --- Determine byte order ---
+		ByteOrder order = "Big-endian".equalsIgnoreCase(byteOrder)
+				? ByteOrder.BIG_ENDIAN
+						: ByteOrder.LITTLE_ENDIAN;
 
-    @Parameter(label = "Spacing Y (mm)", stepSize = "0.00001")
-    private double spacingY = 1.0;
+		// --- Build Dataset ---
+		Dataset dataset = buildDataset(rawData, width, height, depth, pt, order, datasetService);
 
-    @Parameter(label = "Spacing Z (mm)", stepSize = "0.00001")
-    private double spacingZ = 1.0;
+		// --- Apply metadata ---
+		dataset.setName(filePath.getName());
+		dataset.setAxis(new DefaultLinearAxis(Axes.X, "mm", spacingX), 0);
+		dataset.setAxis(new DefaultLinearAxis(Axes.Y, "mm", spacingY), 1);
+		dataset.setAxis(new DefaultLinearAxis(Axes.Z, "mm", spacingZ), 2);
 
-    @Parameter
-    private DatasetService datasetService;
-    
-    @Parameter
-    private DatasetIOService datasetIOService;
-    
-    @Parameter
-    private UIService uiService;
+		return dataset;
+	}
 
-    @Override
-    public void run() {
-        try {
-            // --- Validate ---
-            if (width <= 0 || height <= 0 || depth <= 0) {
-                throw new IllegalArgumentException("Dimensions must be positive integers.");
-            }
+	/**
+	 * Reads raw pixel bytes from a file, skipping the header offset.
+	 */
+	static byte[] readRawBytes(File file, long headerOffset, int dataLength) throws IOException {
+		byte[] rawData = new byte[dataLength];
+		try (FileInputStream fis = new FileInputStream(file)) {
+			long skipped = 0;
+			while (skipped < headerOffset) {
+				long n = fis.skip(headerOffset - skipped);
+				if (n <= 0) {
+					throw new IOException("Unexpected end of stream while skipping header.");
+				}
+				skipped += n;
+			}
 
-            int bytesPerPixel;
-            switch (pixelTypeStr.toLowerCase()) {
-                case "uint8":   bytesPerPixel = 1; break;
-                case "uint16":  bytesPerPixel = 2; break;
-                case "int16":   bytesPerPixel = 2; break;
-                case "float32": bytesPerPixel = 4; break;
-                default:
-                    throw new IllegalArgumentException("Unsupported pixel type: " + pixelTypeStr);
-            }
+			int offset = 0;
+			while (offset < rawData.length) {
+				int nRead = fis.read(rawData, offset, rawData.length - offset);
+				if (nRead == -1) {
+					throw new IOException(String.format(
+							"Unexpected EOF: read %d of %d expected pixel bytes.",
+							offset, rawData.length));
+				}
+				offset += nRead;
+			}
+		}
+		return rawData;
+	}
 
-            long totalPixels = (long) width * height * depth;
-            long expectedDataBytes = totalPixels * bytesPerPixel;
-            long expectedTotalBytes = headerOffset + expectedDataBytes;
+	/**
+	 * Constructs a Dataset from raw bytes based on pixel type.
+	 * Each branch uses the concrete type so Java infers generics correctly.
+	 */
+	static Dataset buildDataset(
+			byte[] rawData,
+			int width, int height, int depth,
+			String pixelType,
+			ByteOrder byteOrder,
+			DatasetService datasetService) {
 
-            File f = filePath;
-            long actualSize = f.length();
-            if (actualSize < expectedTotalBytes) {
-                throw new IOException(String.format(
-                    "File too small: %d bytes available, but %d needed (offset=%d + data=%d).",
-                    actualSize, expectedTotalBytes, headerOffset, expectedDataBytes));
-            }
+		Dataset dataset;
 
-            // --- Read raw bytes, skipping header ---
-            byte[] rawData = new byte[(int) expectedDataBytes];
-            try (FileInputStream fis = new FileInputStream(f)) {
-                long skipped = 0;
-                while (skipped < headerOffset) {
-                    long n = fis.skip(headerOffset - skipped);
-                    if (n <= 0) {
-                        throw new IOException("Unexpected end of stream while skipping header.");
-                    }
-                    skipped += n;
-                }
+		if ("uint8".equals(pixelType)) {
+			var img = ArrayImgs.unsignedBytes(rawData, width, height, depth);
+			dataset = datasetService.create(img);
 
-                int offset = 0;
-                while (offset < rawData.length) {
-                    int nRead = fis.read(rawData, offset, rawData.length - offset);
-                    if (nRead == -1) {
-                        throw new IOException(String.format(
-                            "Unexpected EOF: read %d of %d expected pixel bytes.",
-                            offset, rawData.length));
-                    }
-                    offset += nRead;
-                }
-            }
+		} else if ("uint16".equals(pixelType)) {
+			short[] pixels = new short[rawData.length / 2];
+			ByteBuffer.wrap(rawData).order(byteOrder).asShortBuffer().get(pixels);
+			var img = ArrayImgs.unsignedShorts(pixels, width, height, depth);
+			dataset = datasetService.create(img);
 
-            // Determine ByteOrder enum from string
-            ByteOrder order = "Big-endian".equals(byteOrderStr) 
-                ? ByteOrder.BIG_ENDIAN 
-                : ByteOrder.LITTLE_ENDIAN;
+		} else if ("int16".equals(pixelType)) {
+			short[] pixels = new short[rawData.length / 2];
+			ByteBuffer.wrap(rawData).order(byteOrder).asShortBuffer().get(pixels);
+			var img = ArrayImgs.shorts(pixels, width, height, depth);
+			dataset = datasetService.create(img);
 
-            // --- Build ImgLib2 image AND create Dataset in the same branch ---
-            String typeName = pixelTypeStr.toUpperCase();
+		} else { // float32
+			float[] pixels = new float[rawData.length / 4];
+			ByteBuffer.wrap(rawData).order(byteOrder).asFloatBuffer().get(pixels);
+			var img = ArrayImgs.floats(pixels, width, height, depth);
+			dataset = datasetService.create(img);
+		}
 
-            if ("uint8".equals(pixelTypeStr.toLowerCase())) {
-                var img = ArrayImgs.unsignedBytes(rawData, width, height, depth);
-                dataset = datasetService.create(img);
-            } else if ("uint16".equals(pixelTypeStr.toLowerCase())) {
-                short[] pixels = new short[rawData.length / 2];
-                ByteBuffer.wrap(rawData)
-                    .order(order) 
-                    .asShortBuffer()
-                    .get(pixels);
-                var img = ArrayImgs.unsignedShorts(pixels, width, height, depth);
-                dataset = datasetService.create(img);
-            } else if ("int16".equals(pixelTypeStr.toLowerCase())) {
-                short[] pixels = new short[rawData.length / 2];
-                ByteBuffer.wrap(rawData)
-                    .order(order)
-                    .asShortBuffer()
-                    .get(pixels);
-                var img = ArrayImgs.shorts(pixels, width, height, depth);
-                dataset = datasetService.create(img);
-            } else { // float32
-                float[] pixels = new float[rawData.length / 4];
-                ByteBuffer.wrap(rawData)
-                    .order(order)
-                    .asFloatBuffer()
-                    .get(pixels);
-                var img = ArrayImgs.floats(pixels, width, height, depth);
-                dataset = datasetService.create(img);
-            }
+		return dataset;
+	}
 
-            dataset.setName(filePath.getName());
-            
-            // --- Apply spatial calibration ---
-            dataset.setAxis(new DefaultLinearAxis(Axes.X, "mm", spacingX), 0);
-            dataset.setAxis(new DefaultLinearAxis(Axes.Y, "mm", spacingY), 1);
-            dataset.setAxis(new DefaultLinearAxis(Axes.Z, "mm", spacingZ), 2);
-            
-            if (uiService != null && uiService.isVisible()) {
-                uiService.show(dataset);
-            }
+	/**
+	 * Writes the pixel data of a 3D Dataset to a raw binary file.
+	 * Uses ArrayDataAccess to get the backing array efficiently (no reflection).
+	 *
+	 * @param dataset      The source 3D Dataset.
+	 * @param outputFile   The destination file path.
+	 * @param littleEndian If true, writes as Little-Endian (default). If false, writes Big-Endian.
+	 */
+	public static void saveAsRaw(Dataset dataset, File outputFile, boolean littleEndian) throws IOException {
+		if (dataset.numDimensions() != 3) {
+			throw new IllegalArgumentException("Expected 3D Dataset, got " + dataset.numDimensions() + "D");
+		}
 
-            System.out.println("Loaded 3D image: " + width + "×" + height + "×" + depth
-                + " (" + typeName + ")");
-            System.out.println("  Header offset: " + headerOffset + " bytes");
-            System.out.println("  Byte order: " + byteOrderStr);
-            System.out.printf("  Spacing: x=%.5f, y=%.5f, z=%.5f mm%n", spacingX, spacingY, spacingZ);
-            
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to load raw 3D image: " + e.getMessage(), e);
-        }
-    }
+		final var img = dataset.getImgPlus().getImg();
+		final var type = img.firstElement();
+		final int bytesPerPixel;
+
+		// Determine bytes per pixel
+		if (type instanceof UnsignedByteType || type instanceof ByteType) {
+			bytesPerPixel = 1;
+		} else if (type instanceof UnsignedShortType || type instanceof ShortType) {
+			bytesPerPixel = 2;
+		} else if (type instanceof FloatType) {
+			bytesPerPixel = 4;
+		} else {
+			throw new UnsupportedOperationException("Unsupported pixel type: " + type.getClass().getSimpleName());
+		}
+
+		boolean fastPathUsed = false;
+
+		// --- Fast Path: Use ArrayDataAccess to get the backing array ---
+		if (img instanceof ArrayImg && img instanceof ArrayDataAccess) {
+			try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+				ArrayDataAccess<?> access = (ArrayDataAccess<?>) img;
+				Object storage = access.getCurrentStorageArray();
+
+				if (storage instanceof byte[]) {
+					fos.write((byte[]) storage);
+					fastPathUsed = true;
+				} else if (storage instanceof short[]) {
+					short[] shorts = (short[]) storage;
+					ByteBuffer buffer = ByteBuffer.allocate(shorts.length * 2)
+							.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+					buffer.asShortBuffer().put(shorts);
+					fos.write(buffer.array());
+					fastPathUsed = true;
+				} else if (storage instanceof float[]) {
+					float[] floats = (float[]) storage;
+					ByteBuffer buffer = ByteBuffer.allocate(floats.length * 4)
+							.order(littleEndian ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN);
+					buffer.asFloatBuffer().put(floats);
+					fos.write(buffer.array());
+					fastPathUsed = true;
+				}
+			}
+		}
+
+		// --- Fallback: Cursor Iteration (if not an ArrayImg or access failed) ---
+		if (!fastPathUsed) {
+			try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+				fallbackCursorWrite(fos, img, bytesPerPixel, littleEndian);
+			}
+		}
+	}
+
+	/**
+	 * Fallback method for non-array images.
+	 * Iterates pixels and writes them sequentially.
+	 */
+	private static void fallbackCursorWrite(OutputStream fos, 
+			RandomAccessibleInterval<?> img, 
+			int bytesPerPixel, 
+			boolean littleEndian) throws IOException {
+
+		int batchSize = 65536 / bytesPerPixel; 
+		if (batchSize < 1) batchSize = 1;
+		byte[] batchBuffer = new byte[batchSize * bytesPerPixel];
+		int batchCount = 0;
+
+		// Cursor does NOT implement AutoCloseable
+		var cursor = img.cursor();
+
+		try {
+			while (cursor.hasNext()) {
+				cursor.fwd();
+				Object pixelObj = cursor.get();
+
+				if (bytesPerPixel == 1) {
+					// For 8-bit, we need an integer value between 0-255 (or -128 to 127)
+					// Use getLong() from IntegerType which handles both signed/unsigned
+					long val = -1;
+
+					if (pixelObj instanceof IntegerType<?>) {
+						val = ((IntegerType<?>) pixelObj).getIntegerLong();
+						// Mask to ensure we get the lower 8 bits correctly for unsigned display if needed
+						// But usually raw writes just want the bits.
+						batchBuffer[batchCount++] = (byte) (val & 0xFF);
+					} else if (pixelObj instanceof RealType<?>) {
+						double dVal = ((RealType<?>) pixelObj).getRealDouble();
+						batchBuffer[batchCount++] = (byte) ((int) dVal & 0xFF);
+					} else {
+						throw new IllegalStateException("Unknown pixel type for 8-bit conversion");
+					}
+
+				} else if (bytesPerPixel == 2) {
+					// 16-bit short
+					long val = -1;
+					if (pixelObj instanceof IntegerType<?>) {
+						val = ((IntegerType<?>) pixelObj).getIntegerLong();
+					} else if (pixelObj instanceof RealType<?>) {
+						double dVal = ((RealType<?>) pixelObj).getRealDouble();
+						val = (long) dVal;
+					} else {
+						throw new IllegalStateException("Unknown pixel type for 16-bit conversion");
+					}
+
+					// Ensure we treat it as unsigned 16-bit for writing? 
+					// Actually, we just write the bits.
+					int iv = (int) (val & 0xFFFF);
+
+					if (littleEndian) {
+						batchBuffer[batchCount++] = (byte) (iv & 0xFF);
+						batchBuffer[batchCount++] = (byte) ((iv >> 8) & 0xFF);
+					} else {
+						batchBuffer[batchCount++] = (byte) ((iv >> 8) & 0xFF);
+						batchBuffer[batchCount++] = (byte) (iv & 0xFF);
+					}
+
+				} else if (bytesPerPixel == 4) {
+					// 32-bit float
+					float fVal = 0f;
+					if (pixelObj instanceof FloatType) {
+						fVal = ((FloatType) pixelObj).get();
+					} else if (pixelObj instanceof RealType<?>) {
+						fVal = (float) ((RealType<?>) pixelObj).getRealDouble();
+					} else if (pixelObj instanceof IntegerType<?>) {
+						fVal = ((IntegerType<?>) pixelObj).getIntegerLong();
+					} else {
+						throw new IllegalStateException("Unknown pixel type for 32-bit conversion");
+					}
+
+					int bits = Float.floatToIntBits(fVal);
+					if (littleEndian) {
+						batchBuffer[batchCount++] = (byte) (bits);
+						batchBuffer[batchCount++] = (byte) (bits >> 8);
+						batchBuffer[batchCount++] = (byte) (bits >> 16);
+						batchBuffer[batchCount++] = (byte) (bits >> 24);
+					} else {
+						batchBuffer[batchCount++] = (byte) (bits >> 24);
+						batchBuffer[batchCount++] = (byte) (bits >> 16);
+						batchBuffer[batchCount++] = (byte) (bits >> 8);
+						batchBuffer[batchCount++] = (byte) (bits);
+					}
+				}
+
+				if (batchCount >= batchBuffer.length) {
+					fos.write(batchBuffer, 0, batchCount);
+					batchCount = 0;
+				}
+			}
+
+			if (batchCount > 0) {
+				fos.write(batchBuffer, 0, batchCount);
+			}
+		} finally {
+			// No explicit close needed for Cursor
+			cursor = null;
+		}
+	}
+
+	public static void saveAsRaw(Dataset dataset, File outputFile) throws IOException {
+		saveAsRaw(dataset, outputFile, true);
+	}
 }

--- a/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
@@ -1,0 +1,181 @@
+package org.bonej.utilities;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.axis.Axes;
+import net.imagej.axis.DefaultLinearAxis;
+import net.imglib2.img.array.ArrayImgs;
+
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+
+import io.scif.services.DatasetIOService;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+@Plugin(type = Command.class, menuPath = "Plugins>BoneJ>Load Raw 3D Image")
+public class DatasetUtil implements Command {
+
+    @Parameter(label = "File Path", required = true, style = "file")
+    private File filePath;
+    
+    @Parameter(type = ItemIO.OUTPUT)
+    private Dataset dataset;
+
+    @Parameter(label = "Header Offset (bytes)", min = "0")
+    private long headerOffset = 0;
+
+    @Parameter(label = "Width (X)", required = true, min = "1")
+    private int width;
+
+    @Parameter(label = "Height (Y)", required = true, min = "1")
+    private int height;
+
+    @Parameter(label = "Depth (Z)", required = true, min = "1")
+    private int depth;
+
+    @Parameter(label = "Pixel Type", choices = {"uint8", "uint16", "int16", "float32"}, required = true)
+    private String pixelTypeStr;
+
+    // NEW: Explicit byte order selection
+    @Parameter(label = "Byte Order", choices = {"Little-endian", "Big-endian"}, required = true)
+    private String byteOrderStr;
+
+    @Parameter(label = "Spacing X (mm)", stepSize = "0.00001")
+    private double spacingX = 1.0;
+
+    @Parameter(label = "Spacing Y (mm)", stepSize = "0.00001")
+    private double spacingY = 1.0;
+
+    @Parameter(label = "Spacing Z (mm)", stepSize = "0.00001")
+    private double spacingZ = 1.0;
+
+    @Parameter
+    private DatasetService datasetService;
+    
+    @Parameter
+    private DatasetIOService datasetIOService;
+    
+    @Parameter
+    private UIService uiService;
+
+    @Override
+    public void run() {
+        try {
+            // --- Validate ---
+            if (width <= 0 || height <= 0 || depth <= 0) {
+                throw new IllegalArgumentException("Dimensions must be positive integers.");
+            }
+
+            int bytesPerPixel;
+            switch (pixelTypeStr.toLowerCase()) {
+                case "uint8":   bytesPerPixel = 1; break;
+                case "uint16":  bytesPerPixel = 2; break;
+                case "int16":   bytesPerPixel = 2; break;
+                case "float32": bytesPerPixel = 4; break;
+                default:
+                    throw new IllegalArgumentException("Unsupported pixel type: " + pixelTypeStr);
+            }
+
+            long totalPixels = (long) width * height * depth;
+            long expectedDataBytes = totalPixels * bytesPerPixel;
+            long expectedTotalBytes = headerOffset + expectedDataBytes;
+
+            File f = filePath;
+            long actualSize = f.length();
+            if (actualSize < expectedTotalBytes) {
+                throw new IOException(String.format(
+                    "File too small: %d bytes available, but %d needed (offset=%d + data=%d).",
+                    actualSize, expectedTotalBytes, headerOffset, expectedDataBytes));
+            }
+
+            // --- Read raw bytes, skipping header ---
+            byte[] rawData = new byte[(int) expectedDataBytes];
+            try (FileInputStream fis = new FileInputStream(f)) {
+                long skipped = 0;
+                while (skipped < headerOffset) {
+                    long n = fis.skip(headerOffset - skipped);
+                    if (n <= 0) {
+                        throw new IOException("Unexpected end of stream while skipping header.");
+                    }
+                    skipped += n;
+                }
+
+                int offset = 0;
+                while (offset < rawData.length) {
+                    int nRead = fis.read(rawData, offset, rawData.length - offset);
+                    if (nRead == -1) {
+                        throw new IOException(String.format(
+                            "Unexpected EOF: read %d of %d expected pixel bytes.",
+                            offset, rawData.length));
+                    }
+                    offset += nRead;
+                }
+            }
+
+            // Determine ByteOrder enum from string
+            ByteOrder order = "Big-endian".equals(byteOrderStr) 
+                ? ByteOrder.BIG_ENDIAN 
+                : ByteOrder.LITTLE_ENDIAN;
+
+            // --- Build ImgLib2 image AND create Dataset in the same branch ---
+            String typeName = pixelTypeStr.toUpperCase();
+
+            if ("uint8".equals(pixelTypeStr.toLowerCase())) {
+                var img = ArrayImgs.unsignedBytes(rawData, width, height, depth);
+                dataset = datasetService.create(img);
+            } else if ("uint16".equals(pixelTypeStr.toLowerCase())) {
+                short[] pixels = new short[rawData.length / 2];
+                ByteBuffer.wrap(rawData)
+                    .order(order) 
+                    .asShortBuffer()
+                    .get(pixels);
+                var img = ArrayImgs.unsignedShorts(pixels, width, height, depth);
+                dataset = datasetService.create(img);
+            } else if ("int16".equals(pixelTypeStr.toLowerCase())) {
+                short[] pixels = new short[rawData.length / 2];
+                ByteBuffer.wrap(rawData)
+                    .order(order)
+                    .asShortBuffer()
+                    .get(pixels);
+                var img = ArrayImgs.shorts(pixels, width, height, depth);
+                dataset = datasetService.create(img);
+            } else { // float32
+                float[] pixels = new float[rawData.length / 4];
+                ByteBuffer.wrap(rawData)
+                    .order(order)
+                    .asFloatBuffer()
+                    .get(pixels);
+                var img = ArrayImgs.floats(pixels, width, height, depth);
+                dataset = datasetService.create(img);
+            }
+
+            dataset.setName(filePath.getName());
+            
+            // --- Apply spatial calibration ---
+            dataset.setAxis(new DefaultLinearAxis(Axes.X, "mm", spacingX), 0);
+            dataset.setAxis(new DefaultLinearAxis(Axes.Y, "mm", spacingY), 1);
+            dataset.setAxis(new DefaultLinearAxis(Axes.Z, "mm", spacingZ), 2);
+            
+            if (uiService != null && uiService.isVisible()) {
+                uiService.show(dataset);
+            }
+
+            System.out.println("Loaded 3D image: " + width + "×" + height + "×" + depth
+                + " (" + typeName + ")");
+            System.out.println("  Header offset: " + headerOffset + " bytes");
+            System.out.println("  Byte order: " + byteOrderStr);
+            System.out.printf("  Spacing: x=%.5f, y=%.5f, z=%.5f mm%n", spacingX, spacingY, spacingZ);
+            
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load raw 3D image: " + e.getMessage(), e);
+        }
+    }
+}

--- a/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
@@ -2,6 +2,16 @@ package org.bonej.utilities;
 
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
+import net.imagej.ImgPlus;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import org.junit.After;
 import org.junit.Before;
@@ -26,204 +36,546 @@ import static org.mockito.Mockito.*;
  */
 public class DatasetUtilTest {
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
-    private DatasetService mockDatasetService;
+	private DatasetService mockDatasetService;
 
-    @Before
-    public void setUp() {
-        // Mock the service to avoid needing a full ImageJ context for basic tests
-        mockDatasetService = mock(DatasetService.class);
-        
-        // Since we can't easily create a real Dataset without an ImageJ instance,
-        // we will test the static helper methods that don't strictly require it
-        // or use mocks where necessary.
-        // For buildDataset, we expect it to fail if called without a working service,
-        // so we'll primarily test readRawBytes and validation logic here.
-    }
+	@Before
+	public void setUp() {
+		// Mock the service to avoid needing a full ImageJ context for basic tests
+		mockDatasetService = mock(DatasetService.class);
 
-    @After
-    public void tearDown() {
-        mockDatasetService = null;
-    }
+		// Since we can't easily create a real Dataset without an ImageJ instance,
+		// we will test the static helper methods that don't strictly require it
+		// or use mocks where necessary.
+		// For buildDataset, we expect it to fail if called without a working service,
+		// so we'll primarily test readRawBytes and validation logic here.
+	}
 
-    /**
-     * Test that loadRaw3D throws IllegalArgumentException for invalid dimensions.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadRaw3D_InvalidWidth() throws Exception {
-        File dummy = tempFolder.newFile("dummy.raw");
-        dummy.deleteOnExit(); // Just needs to exist
-        
-        DatasetUtil.loadRaw3D(
-            dummy, 0, -5, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+	@After
+	public void tearDown() {
+		mockDatasetService = null;
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadRaw3D_InvalidHeight() throws Exception {
-        File dummy = tempFolder.newFile("dummy.raw");
-        DatasetUtil.loadRaw3D(
-            dummy, 0, 10, 0, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+	/**
+	 * Test that loadRaw3D throws IllegalArgumentException for invalid dimensions.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_InvalidWidth() throws Exception {
+		File dummy = tempFolder.newFile("dummy.raw");
+		dummy.deleteOnExit(); // Just needs to exist
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadRaw3D_InvalidDepth() throws Exception {
-        File dummy = tempFolder.newFile("dummy.raw");
-        DatasetUtil.loadRaw3D(
-            dummy, 0, 10, 10, -1, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+		DatasetUtil.loadRaw3D(
+				dummy, 0, -5, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-    /**
-     * Test that loadRaw3D throws IllegalArgumentException for non-existent file.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadRaw3D_NonExistentFile() throws Exception {
-        File nonexistent = new File("/nonexistent/dummy.raw");
-        DatasetUtil.loadRaw3D(
-            nonexistent, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_InvalidHeight() throws Exception {
+		File dummy = tempFolder.newFile("dummy.raw");
+		DatasetUtil.loadRaw3D(
+				dummy, 0, 10, 0, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-    /**
-     * Test that loadRaw3D throws IllegalArgumentException for unsupported pixel type.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testLoadRaw3D_UnsupportedPixelType() throws Exception {
-        File file = tempFolder.newFile("test.raw");
-        Files.write(file.toPath(), new byte[100]);
-        
-        DatasetUtil.loadRaw3D(
-            file, 0, 5, 5, 4, "invalid_type", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_InvalidDepth() throws Exception {
+		File dummy = tempFolder.newFile("dummy.raw");
+		DatasetUtil.loadRaw3D(
+				dummy, 0, 10, 10, -1, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-    /**
-     * Test that loadRaw3D throws IOException when file is too small.
-     */
-    @Test(expected = IOException.class)
-    public void testLoadRaw3D_FileTooSmall() throws Exception {
-        // Need 10x10x10 uint8 = 1000 bytes. File has only 10.
-        byte[] smallData = new byte[10];
-        File file = writeDataToFile(smallData, "small.raw");
-        
-        DatasetUtil.loadRaw3D(
-            file, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-        );
-    }
+	/**
+	 * Test that loadRaw3D throws IllegalArgumentException for non-existent file.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_NonExistentFile() throws Exception {
+		File nonexistent = new File("/nonexistent/dummy.raw");
+		DatasetUtil.loadRaw3D(
+				nonexistent, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-    /**
-     * Test readRawBytes reads correctly with no offset.
-     */
-    @Test
-    public void testReadRawBytes_NoOffset() throws Exception {
-        byte[] expected = {1, 2, 3, 4, 5};
-        File file = writeDataToFile(expected, "read_test.raw");
-        
-        byte[] result = DatasetUtil.readRawBytes(file, 0, 5);
-        
-        assertArrayEquals("Data should match exactly", expected, result);
-    }
+	/**
+	 * Test that loadRaw3D throws IllegalArgumentException for unsupported pixel type.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_UnsupportedPixelType() throws Exception {
+		File file = tempFolder.newFile("test.raw");
+		Files.write(file.toPath(), new byte[100]);
 
-    /**
-     * Test readRawBytes skips header correctly.
-     */
-    @Test
-    public void testReadRawBytes_WithHeaderOffset() throws Exception {
-        byte[] header = {-1, -2, -3, 4, 5}; // Header data
-        byte[] payload = {10, 20, 30};      // Data to read
-        
-        byte[] combined = new byte[header.length + payload.length];
-        System.arraycopy(header, 0, combined, 0, header.length);
-        System.arraycopy(payload, 0, combined, header.length, payload.length);
-        
-        File file = writeDataToFile(combined, "offset_test.raw");
-        
-        byte[] result = DatasetUtil.readRawBytes(file, header.length, payload.length);
-        
-        assertArrayEquals("Payload should be read after skipping header", payload, result);
-        
-        // Verify header was skipped
-        assertNotEquals("Header content should not be in result", 
-                        header[0], result[0]);
-    }
+		DatasetUtil.loadRaw3D(
+				file, 0, 5, 5, 4, "invalid_type", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-    /**
-     * Test readRawBytes handles partial reads correctly (simulated by large buffer).
-     */
-    @Test
-    public void testReadRawBytes_LargeBlock() throws Exception {
-        int size = 1024;
-        byte[] data = new byte[size];
-        for(int i=0; i<size; i++) data[i] = (byte)(i % 256);
-        
-        File file = writeDataToFile(data, "large_block.raw");
-        
-        byte[] result = DatasetUtil.readRawBytes(file, 0, size);
-        
-        assertArrayEquals("Large block read failed", data, result);
-    }
+	/**
+	 * Test that loadRaw3D throws IOException when file is too small.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadRaw3D_FileTooSmall() throws Exception {
+		// Need 10x10x10 uint8 = 1000 bytes. File has only 10.
+		byte[] smallData = new byte[10];
+		File file = writeDataToFile(smallData, "small.raw");
 
-    /**
-     * Test that endianness conversion works as expected in a standalone scenario.
-     * This verifies the ByteBuffer logic used in buildDataset.
-     */
-    @Test
-    public void testEndiannessConversion() {
-        // Test Short (uint16/int16)
-        short[] shorts = {1, 258, 513}; // 0x0001, 0x0102, 0x0201
-        ByteBuffer leBuffer = ByteBuffer.allocate(shorts.length * 2).order(ByteOrder.LITTLE_ENDIAN);
-        ByteBuffer beBuffer = ByteBuffer.allocate(shorts.length * 2).order(ByteOrder.BIG_ENDIAN);
+		DatasetUtil.loadRaw3D(
+				file, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+				);
+	}
 
-        leBuffer.asShortBuffer().put(shorts);
-        beBuffer.asShortBuffer().put(shorts);
+	/**
+	 * Test readRawBytes reads correctly with no offset.
+	 */
+	@Test
+	public void testReadRawBytes_NoOffset() throws Exception {
+		byte[] expected = {1, 2, 3, 4, 5};
+		File file = writeDataToFile(expected, "read_test.raw");
 
-        byte[] leBytes = leBuffer.array();
-        byte[] beBytes = beBuffer.array();
+		byte[] result = DatasetUtil.readRawBytes(file, 0, 5);
 
-        // Value 1 (0x0001): LE=[0x01, 0x00], BE=[0x00, 0x01]
-        assertEquals((byte) 1, leBytes[0]);
-        assertEquals((byte) 0, beBytes[0]);
+		assertArrayEquals("Data should match exactly", expected, result);
+	}
 
-        // Value 258 (0x0102): LE=[0x02, 0x01], BE=[0x01, 0x02]
-        assertEquals((byte) 2, leBytes[2]);
-        assertEquals((byte) 1, leBytes[3]);
-        assertEquals((byte) 1, beBytes[2]);
-        assertEquals((byte) 2, beBytes[3]);
+	/**
+	 * Test readRawBytes skips header correctly.
+	 */
+	@Test
+	public void testReadRawBytes_WithHeaderOffset() throws Exception {
+		byte[] header = {-1, -2, -3, 4, 5}; // Header data
+		byte[] payload = {10, 20, 30};      // Data to read
 
-        // Test Float (float32)
-        float[] floats = {1.0f, 2.0f};
-        ByteBuffer leF = ByteBuffer.allocate(floats.length * 4).order(ByteOrder.LITTLE_ENDIAN);
-        ByteBuffer beF = ByteBuffer.allocate(floats.length * 4).order(ByteOrder.BIG_ENDIAN);
+		byte[] combined = new byte[header.length + payload.length];
+		System.arraycopy(header, 0, combined, 0, header.length);
+		System.arraycopy(payload, 0, combined, header.length, payload.length);
 
-        leF.asFloatBuffer().put(floats);
-        beF.asFloatBuffer().put(floats);
+		File file = writeDataToFile(combined, "offset_test.raw");
 
-        byte[] leFBytes = leF.array();
-        byte[] beFBytes = beF.array();
+		byte[] result = DatasetUtil.readRawBytes(file, header.length, payload.length);
 
-        assertNotEquals("Floats should have different byte orders",
-                Arrays.hashCode(leFBytes), Arrays.hashCode(beFBytes));
-    }
+		assertArrayEquals("Payload should be read after skipping header", payload, result);
 
-    /**
-     * Test saveAsRaw method existence and basic parameter handling.
-     * Actual functionality requires a populated Dataset which is hard to mock without ImageJ.
-     */
-    @Test
-    public void testSaveAsRaw_MethodExists() throws Exception {
-        // Verify the method signature exists
-        DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class, boolean.class);
-        DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class);
-    }
+		// Verify header was skipped
+		assertNotEquals("Header content should not be in result", 
+				header[0], result[0]);
+	}
 
-    // Helper to create a test file with data
-    private File writeDataToFile(byte[] data, String filename) throws Exception {
-        File file = tempFolder.newFile(filename);
-        java.nio.file.Files.write(file.toPath(), data);
-        return file;
-    }
+	/**
+	 * Test readRawBytes handles partial reads correctly (simulated by large buffer).
+	 */
+	@Test
+	public void testReadRawBytes_LargeBlock() throws Exception {
+		int size = 1024;
+		byte[] data = new byte[size];
+		for(int i=0; i<size; i++) data[i] = (byte)(i % 256);
+
+		File file = writeDataToFile(data, "large_block.raw");
+
+		byte[] result = DatasetUtil.readRawBytes(file, 0, size);
+
+		assertArrayEquals("Large block read failed", data, result);
+	}
+
+	/**
+	 * Test saveAsRaw method existence and basic parameter handling.
+	 * Actual functionality requires a populated Dataset which is hard to mock without ImageJ.
+	 */
+	@Test
+	public void testSaveAsRaw_MethodExists() throws Exception {
+		// Verify the method signature exists
+		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class, boolean.class);
+		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class);
+	}
+
+	// Helper to create a test file with data
+	private File writeDataToFile(byte[] data, String filename) throws Exception {
+		File file = tempFolder.newFile(filename);
+		java.nio.file.Files.write(file.toPath(), data);
+		return file;
+	}
+
+
+	//^ ^Tests wrking above this line =========
+	/**
+	 * Test that loadRaw3D throws IllegalArgumentException for null file.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_NullFile() throws Exception {
+		DatasetUtil.loadRaw3D(null, 0, 10, 10, 10, "uint8",
+				"Little-endian", 1.0, 1.0, 1.0, mockDatasetService);
+	}
+
+	/**
+	 * Test that loadRaw3D throws IOException when header offset exceeds file size.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadRaw3D_HeaderOffsetExceedsFile() throws Exception {
+		// 10-byte file, 100-byte header offset means we can't even skip the header
+		File file = writeDataToFile(new byte[10], "tiny.raw");
+		DatasetUtil.loadRaw3D(file, 100, 2, 2, 2, "uint8",
+				"Little-endian", 1.0, 1.0, 1.0, mockDatasetService);
+	}
+
+	/**
+	 * Test readRawBytes with zero-length read (should return empty array, not throw).
+	 */
+	@Test
+	public void testReadRawBytes_ZeroLengthRead() throws Exception {
+		byte[] data = {1, 2, 3};
+		File file = writeDataToFile(data, "zero_read.raw");
+		byte[] result = DatasetUtil.readRawBytes(file, 0, 0);
+		assertEquals("Zero-length read should return empty array", 0, result.length);
+	}
+
+	/**
+	 * Test readRawBytes fails if requested bytes exceed actual file size after offset.
+	 */
+	@Test(expected = IOException.class)
+	public void testReadRawBytes_TruncatedFile() throws Exception {
+		// Request 100 bytes but file only has 50
+		File file = writeDataToFile(new byte[50], "truncated.raw");
+		DatasetUtil.readRawBytes(file, 0, 100);
+	}
+
+	/**
+	 * Test buildDataset creates correct type for uint8.
+	 */
+	@Test
+	public void testBuildDataset_Uint8() throws Exception {
+		int w = 4, h = 3, d = 2;
+		byte[] rawData = new byte[w * h * d];
+		for (int i = 0; i < rawData.length; i++) rawData[i] = (byte) i;
+
+		// Create a mock Dataset
+		Dataset mockDs = mock(Dataset.class);
+
+		// Stub DatasetService.create to return the mock Dataset for any Img
+		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
+
+		// Call buildDataset
+		Dataset result = DatasetUtil.buildDataset(
+				rawData, w, h, d, "uint8", ByteOrder.LITTLE_ENDIAN, mockDatasetService
+				);
+
+		// Verify the result is the mock Dataset
+		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
+
+		// Verify DatasetService.create was called with an Img
+		verify(mockDatasetService).create(any(Img.class));
+	}
+
+	/**
+	 * Test buildDataset creates correct type for uint16.
+	 */
+	@Test
+	public void testBuildDataset_Uint16() throws Exception {
+		int w = 2, h = 2, d = 2;
+		short[] values = {100, 2000, 30000, 500, 999, 1234, 32000, 0};
+		ByteBuffer bb = ByteBuffer.allocate(values.length * 2).order(ByteOrder.LITTLE_ENDIAN);
+		bb.asShortBuffer().put(values);
+
+		Dataset mockDs = mock(Dataset.class);
+		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
+
+		Dataset result = DatasetUtil.buildDataset(
+				bb.array(), w, h, d, "uint16", ByteOrder.LITTLE_ENDIAN, mockDatasetService
+				);
+
+		assertSame(mockDs, result);
+		verify(mockDatasetService).create(any(Img.class));
+	}
+
+	/**
+	 * Test buildDataset creates correct type for int16 (including negatives).
+	 */
+	@Test
+	public void testBuildDataset_Int16() throws Exception {
+		int w = 2, h = 2, d = 2;
+		short[] values = {-100, 2000, -30000, 500, -999, 1234, -1, 0};
+		ByteBuffer bb = ByteBuffer.allocate(values.length * 2).order(ByteOrder.LITTLE_ENDIAN);
+		bb.asShortBuffer().put(values);
+
+		// Create a mock Dataset
+		Dataset mockDs = mock(Dataset.class);
+
+		// Stub DatasetService.create to return the mock Dataset for any Img
+		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
+
+		// Call buildDataset
+		Dataset result = DatasetUtil.buildDataset(
+				bb.array(), w, h, d, "int16", ByteOrder.LITTLE_ENDIAN, mockDatasetService
+				);
+
+		// Verify the result is the mock Dataset
+		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
+
+		// Verify DatasetService.create was called with an Img
+		verify(mockDatasetService).create(any(Img.class));
+	}
+
+	/**
+	 * Test buildDataset creates correct type for float32 (including NaN/Inf).
+	 */
+	@Test
+	public void testBuildDataset_Float32() throws Exception {
+		int w = 2, h = 2, d = 2;
+		float[] values = {1.0f, -2.5f, 3.14f, 0.0f, 100.0f, -0.001f, 1e10f, Float.NaN};
+		ByteBuffer bb = ByteBuffer.allocate(values.length * 4).order(ByteOrder.BIG_ENDIAN);
+		bb.asFloatBuffer().put(values);
+
+		// Create a mock Dataset
+		Dataset mockDs = mock(Dataset.class);
+
+		// Stub DatasetService.create to return the mock Dataset for any Img
+		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
+
+		// Call buildDataset
+		Dataset result = DatasetUtil.buildDataset(
+				bb.array(), w, h, d, "float32", ByteOrder.BIG_ENDIAN, mockDatasetService
+				);
+
+		// Verify the result is the mock Dataset
+		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
+
+		// Verify DatasetService.create was called with an Img
+		verify(mockDatasetService).create(any(Img.class));
+	}
+
+	/**
+	 * Round-trip test: Write uint8 ArrayImg to raw file and read back.
+	 */
+	@Test
+	public void testSaveAsRaw_Uint8ArrayImg() throws Exception {
+		int w = 4, h = 3, d = 2;
+		ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(w, h, d);
+
+		byte[] expectedBytes = new byte[w * h * d];
+		int idx = 0;
+		var cursor = img.cursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			byte val = (byte) idx;
+			cursor.get().set(val);
+			expectedBytes[idx++] = val;
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_uint8.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile, true);
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		assertArrayEquals("uint8 round-trip failed", expectedBytes, written);
+	}
+
+	/**
+	 * Round-trip test: Write uint16 ArrayImg to raw file (Little-Endian) and read back.
+	 */
+	@Test
+	public void testSaveAsRaw_Uint16ArrayImg_LittleEndian() throws Exception {
+		int w = 3, h = 2, d = 2;
+		ArrayImg<UnsignedShortType, ShortArray> img = ArrayImgs.unsignedShorts(w, h, d);
+
+		short[] expectedValues = new short[w * h * d];
+		var cursor = img.cursor();
+		for (int i = 0; i < expectedValues.length; i++) {
+			cursor.fwd();
+			short val = (short) (i * 1000);
+			cursor.get().set(val & 0xFFFF);
+			expectedValues[i] = val;
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_uint16_le.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile, true);
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		ByteBuffer bb = ByteBuffer.wrap(written).order(ByteOrder.LITTLE_ENDIAN);
+		short[] result = new short[expectedValues.length];
+		bb.asShortBuffer().get(result);
+
+		assertArrayEquals("uint16 LE round-trip failed", expectedValues, result);
+	}
+
+	/**
+	 * Round-trip test: Write uint16 ArrayImg to raw file (Big-Endian) and read back.
+	 */
+	@Test
+	public void testSaveAsRaw_Uint16ArrayImg_BigEndian() throws Exception {
+		int w = 2, h = 2, d = 2;
+		ArrayImg<UnsignedShortType, ShortArray> img = ArrayImgs.unsignedShorts(w, h, d);
+
+		short[] expectedValues = new short[w * h * d];
+		var cursor = img.cursor();
+		for (int i = 0; i < expectedValues.length; i++) {
+			cursor.fwd();
+			short val = (short) (i * 500 + 100);
+			cursor.get().set(val & 0xFFFF);
+			expectedValues[i] = val;
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_uint16_be.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile, false);
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		ByteBuffer bb = ByteBuffer.wrap(written).order(ByteOrder.BIG_ENDIAN);
+		short[] result = new short[expectedValues.length];
+		bb.asShortBuffer().get(result);
+
+		assertArrayEquals("uint16 BE round-trip failed", expectedValues, result);
+	}
+
+	/**
+	 * Round-trip test: Write float32 ArrayImg to raw file (Little-Endian) and read back.
+	 */
+	@Test
+	public void testSaveAsRaw_Float32ArrayImg_LittleEndian() throws Exception {
+		int w = 2, h = 3, d = 2;
+		ArrayImg<FloatType, FloatArray> img = ArrayImgs.floats(w, h, d);
+
+		float[] expectedValues = new float[w * h * d];
+		var cursor = img.cursor();
+		for (int i = 0; i < expectedValues.length; i++) {
+			cursor.fwd();
+			float val = i * 1.5f - 3.0f;
+			cursor.get().set(val);
+			expectedValues[i] = val;
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_float32_le.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile, true);
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		ByteBuffer bb = ByteBuffer.wrap(written).order(ByteOrder.LITTLE_ENDIAN);
+		float[] result = new float[expectedValues.length];
+		bb.asFloatBuffer().get(result);
+
+		assertArrayEquals("float32 LE round-trip failed", expectedValues, result, 0.0f);
+	}
+
+	/**
+	 * Round-trip test: Write float32 ArrayImg to raw file (Big-Endian) and read back.
+	 */
+	@Test
+	public void testSaveAsRaw_Float32ArrayImg_BigEndian() throws Exception {
+		int w = 2, h = 2, d = 2;
+		ArrayImg<FloatType, FloatArray> img = ArrayImgs.floats(w, h, d);
+
+		float[] expectedValues = new float[w * h * d];
+		var cursor = img.cursor();
+		for (int i = 0; i < expectedValues.length; i++) {
+			cursor.fwd();
+			float val = (float) Math.sqrt(i) - 1.0f;
+			cursor.get().set(val);
+			expectedValues[i] = val;
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_float32_be.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile, false);
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		ByteBuffer bb = ByteBuffer.wrap(written).order(ByteOrder.BIG_ENDIAN);
+		float[] result = new float[expectedValues.length];
+		bb.asFloatBuffer().get(result);
+
+		assertArrayEquals("float32 BE round-trip failed", expectedValues, result, 0.0f);
+	}
+
+	/**
+	 * Test that the no-arg saveAsRaw defaults to little-endian.
+	 */
+	@Test
+	public void testSaveAsRaw_DefaultIsLittleEndian() throws Exception {
+		int w = 2, h = 2, d = 1;
+		ArrayImg<UnsignedShortType, ShortArray> img = ArrayImgs.unsignedShorts(w, h, d);
+
+		short val = 0x0102; // Distinct high/low bytes
+		var cursor = img.cursor();
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			cursor.get().set(val);
+		}
+
+		Dataset ds = wrapInMockDataset(img, w, h, d);
+		File outFile = tempFolder.newFile("out_default_endian.raw");
+
+		DatasetUtil.saveAsRaw(ds, outFile); // No endian arg -> default (LE)
+
+		byte[] written = Files.readAllBytes(outFile.toPath());
+		// Little-endian: low byte first → 0x02, 0x01
+		assertEquals("Default should be little-endian (low byte first)",
+				(byte) 0x02, written[0]);
+		assertEquals((byte) 0x01, written[1]);
+	}
+
+	/**
+	 * Ensure saveAsRaw rejects non-3D datasets.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testSaveAsRaw_Non3DDataset() throws Exception {
+		ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(4, 3); // 2D
+		Dataset ds = wrapInMockDataset(img, 4, 3);
+
+		File outFile = tempFolder.newFile("out_2d.raw");
+		DatasetUtil.saveAsRaw(ds, outFile);
+	}
+
+	/**
+	 * Improved endianness check using Arrays.equals instead of hashCode.
+	 */
+	@Test
+	public void testEndiannessConversion() {
+		short[] shorts = {1, 258, 513};
+		ByteBuffer leBuffer = ByteBuffer.allocate(shorts.length * 2)
+				.order(ByteOrder.LITTLE_ENDIAN);
+		ByteBuffer beBuffer = ByteBuffer.allocate(shorts.length * 2)
+				.order(ByteOrder.BIG_ENDIAN);
+
+		leBuffer.asShortBuffer().put(shorts);
+		beBuffer.asShortBuffer().put(shorts);
+
+		assertFalse("Short byte representations should differ by endianness",
+				Arrays.equals(leBuffer.array(), beBuffer.array()));
+
+		float[] floats = {1.0f, 2.0f};
+		ByteBuffer leF = ByteBuffer.allocate(floats.length * 4)
+				.order(ByteOrder.LITTLE_ENDIAN);
+		ByteBuffer beF = ByteBuffer.allocate(floats.length * 4)
+				.order(ByteOrder.BIG_ENDIAN);
+
+		leF.asFloatBuffer().put(floats);
+		beF.asFloatBuffer().put(floats);
+
+		assertFalse("Float byte representations should differ by endianness",
+				Arrays.equals(leF.array(), beF.array()));
+	}
+
+	/**
+	 * Helper to create a mock Dataset wrapping a real ArrayImg.
+	 * Uses raw types for Mockito stubbing to avoid wildcard issues.
+	 */
+	@SuppressWarnings("unchecked")
+	private Dataset wrapInMockDataset(Object imgObj, long... dims) {
+		// Cast the input image to the raw Img interface
+		Img img = (Img) imgObj;
+
+		// Create mocks using raw types
+		Dataset ds = mock(Dataset.class);
+		ImgPlus imgPlus = mock(ImgPlus.class);
+
+		// Stub the methods using raw types
+		when(ds.numDimensions()).thenReturn(dims.length);
+		when(ds.getImgPlus()).thenReturn(imgPlus);
+		when(imgPlus.getImg()).thenReturn(img);
+
+		return ds;
+	}
 }

--- a/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
@@ -1,0 +1,229 @@
+package org.bonej.utilities;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for DatasetUtil.
+ * Note: Full integration tests require a real ImageJ context.
+ * These tests focus on validation, file I/O logic, and byte manipulation.
+ */
+public class DatasetUtilTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private DatasetService mockDatasetService;
+
+    @Before
+    public void setUp() {
+        // Mock the service to avoid needing a full ImageJ context for basic tests
+        mockDatasetService = mock(DatasetService.class);
+        
+        // Since we can't easily create a real Dataset without an ImageJ instance,
+        // we will test the static helper methods that don't strictly require it
+        // or use mocks where necessary.
+        // For buildDataset, we expect it to fail if called without a working service,
+        // so we'll primarily test readRawBytes and validation logic here.
+    }
+
+    @After
+    public void tearDown() {
+        mockDatasetService = null;
+    }
+
+    /**
+     * Test that loadRaw3D throws IllegalArgumentException for invalid dimensions.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadRaw3D_InvalidWidth() throws Exception {
+        File dummy = tempFolder.newFile("dummy.raw");
+        dummy.deleteOnExit(); // Just needs to exist
+        
+        DatasetUtil.loadRaw3D(
+            dummy, 0, -5, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadRaw3D_InvalidHeight() throws Exception {
+        File dummy = tempFolder.newFile("dummy.raw");
+        DatasetUtil.loadRaw3D(
+            dummy, 0, 10, 0, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadRaw3D_InvalidDepth() throws Exception {
+        File dummy = tempFolder.newFile("dummy.raw");
+        DatasetUtil.loadRaw3D(
+            dummy, 0, 10, 10, -1, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    /**
+     * Test that loadRaw3D throws IllegalArgumentException for non-existent file.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadRaw3D_NonExistentFile() throws Exception {
+        File nonexistent = new File("/nonexistent/dummy.raw");
+        DatasetUtil.loadRaw3D(
+            nonexistent, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    /**
+     * Test that loadRaw3D throws IllegalArgumentException for unsupported pixel type.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testLoadRaw3D_UnsupportedPixelType() throws Exception {
+        File file = tempFolder.newFile("test.raw");
+        Files.write(file.toPath(), new byte[100]);
+        
+        DatasetUtil.loadRaw3D(
+            file, 0, 5, 5, 4, "invalid_type", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    /**
+     * Test that loadRaw3D throws IOException when file is too small.
+     */
+    @Test(expected = IOException.class)
+    public void testLoadRaw3D_FileTooSmall() throws Exception {
+        // Need 10x10x10 uint8 = 1000 bytes. File has only 10.
+        byte[] smallData = new byte[10];
+        File file = writeDataToFile(smallData, "small.raw");
+        
+        DatasetUtil.loadRaw3D(
+            file, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+        );
+    }
+
+    /**
+     * Test readRawBytes reads correctly with no offset.
+     */
+    @Test
+    public void testReadRawBytes_NoOffset() throws Exception {
+        byte[] expected = {1, 2, 3, 4, 5};
+        File file = writeDataToFile(expected, "read_test.raw");
+        
+        byte[] result = DatasetUtil.readRawBytes(file, 0, 5);
+        
+        assertArrayEquals("Data should match exactly", expected, result);
+    }
+
+    /**
+     * Test readRawBytes skips header correctly.
+     */
+    @Test
+    public void testReadRawBytes_WithHeaderOffset() throws Exception {
+        byte[] header = {-1, -2, -3, 4, 5}; // Header data
+        byte[] payload = {10, 20, 30};      // Data to read
+        
+        byte[] combined = new byte[header.length + payload.length];
+        System.arraycopy(header, 0, combined, 0, header.length);
+        System.arraycopy(payload, 0, combined, header.length, payload.length);
+        
+        File file = writeDataToFile(combined, "offset_test.raw");
+        
+        byte[] result = DatasetUtil.readRawBytes(file, header.length, payload.length);
+        
+        assertArrayEquals("Payload should be read after skipping header", payload, result);
+        
+        // Verify header was skipped
+        assertNotEquals("Header content should not be in result", 
+                        header[0], result[0]);
+    }
+
+    /**
+     * Test readRawBytes handles partial reads correctly (simulated by large buffer).
+     */
+    @Test
+    public void testReadRawBytes_LargeBlock() throws Exception {
+        int size = 1024;
+        byte[] data = new byte[size];
+        for(int i=0; i<size; i++) data[i] = (byte)(i % 256);
+        
+        File file = writeDataToFile(data, "large_block.raw");
+        
+        byte[] result = DatasetUtil.readRawBytes(file, 0, size);
+        
+        assertArrayEquals("Large block read failed", data, result);
+    }
+
+    /**
+     * Test that endianness conversion works as expected in a standalone scenario.
+     * This verifies the ByteBuffer logic used in buildDataset.
+     */
+    @Test
+    public void testEndiannessConversion() {
+        // Test Short (uint16/int16)
+        short[] shorts = {1, 258, 513}; // 0x0001, 0x0102, 0x0201
+        ByteBuffer leBuffer = ByteBuffer.allocate(shorts.length * 2).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer beBuffer = ByteBuffer.allocate(shorts.length * 2).order(ByteOrder.BIG_ENDIAN);
+
+        leBuffer.asShortBuffer().put(shorts);
+        beBuffer.asShortBuffer().put(shorts);
+
+        byte[] leBytes = leBuffer.array();
+        byte[] beBytes = beBuffer.array();
+
+        // Value 1 (0x0001): LE=[0x01, 0x00], BE=[0x00, 0x01]
+        assertEquals((byte) 1, leBytes[0]);
+        assertEquals((byte) 0, beBytes[0]);
+
+        // Value 258 (0x0102): LE=[0x02, 0x01], BE=[0x01, 0x02]
+        assertEquals((byte) 2, leBytes[2]);
+        assertEquals((byte) 1, leBytes[3]);
+        assertEquals((byte) 1, beBytes[2]);
+        assertEquals((byte) 2, beBytes[3]);
+
+        // Test Float (float32)
+        float[] floats = {1.0f, 2.0f};
+        ByteBuffer leF = ByteBuffer.allocate(floats.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer beF = ByteBuffer.allocate(floats.length * 4).order(ByteOrder.BIG_ENDIAN);
+
+        leF.asFloatBuffer().put(floats);
+        beF.asFloatBuffer().put(floats);
+
+        byte[] leFBytes = leF.array();
+        byte[] beFBytes = beF.array();
+
+        assertNotEquals("Floats should have different byte orders",
+                Arrays.hashCode(leFBytes), Arrays.hashCode(beFBytes));
+    }
+
+    /**
+     * Test saveAsRaw method existence and basic parameter handling.
+     * Actual functionality requires a populated Dataset which is hard to mock without ImageJ.
+     */
+    @Test
+    public void testSaveAsRaw_MethodExists() throws Exception {
+        // Verify the method signature exists
+        DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class, boolean.class);
+        DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class);
+    }
+
+    // Helper to create a test file with data
+    private File writeDataToFile(byte[] data, String filename) throws Exception {
+        File file = tempFolder.newFile(filename);
+        java.nio.file.Files.write(file.toPath(), data);
+        return file;
+    }
+}


### PR DESCRIPTION
Having BoneJ available to XamFlow needs smooth integration work. XamFlow uses Python to access external resources. Modernising all BoneJ's IO, using `Dataset` and `SharedTable` is done, now need to make sure that XamFlow can get its data into BoneJ's plugins. It uses its own `omni` file format which has a metadata file `.omni` and pixel data in a separate `raw` file.