### PR TITLE
Improve Connectivity's relationship with Datasets and ImagePlus

### DIFF
--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -34,13 +34,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bonej.util.ImageCheck;
 import org.bonej.util.Multithreader;
+import org.bonej.utilities.ImagePlusUtil;
 import org.bonej.utilities.SharedTable;
 import org.bonej.wrapperPlugins.BoneJCommand;
+import org.bonej.wrapperPlugins.CommonMessages;
+import org.scijava.ItemIO;
 import org.scijava.command.Command;
 import org.scijava.convert.ConvertService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
 
 import ij.IJ;
 import ij.ImagePlus;
@@ -119,8 +123,12 @@ public class Connectivity extends BoneJCommand implements Command {
 	private int depth = 0;
 
 	/* IJ2 parameters */
-	@Parameter
+	@Parameter (type = ItemIO.INPUT, required = false)
     private Dataset inputDataset;
+
+	/* Algorithm is faster on native ImagePlus if it can be provided */
+	@Parameter (type = ItemIO.INPUT, required = false)
+    private ImagePlus inputImagePlus;
 	
 	@Parameter
 	private ConvertService convertService;
@@ -128,20 +136,42 @@ public class Connectivity extends BoneJCommand implements Command {
 	@Parameter
 	private LogService logService;
 	
+	@Parameter
+	private UIService uiService;
+	
 	/**
 	 * Modern scijava Plugin entry point.
 	 */
 	@Override
 	public void run() {
-        ImagePlus imp = convertService.convert(inputDataset, ImagePlus.class);
-        
-        if (imp == null) {
-            logService.error("Connectivity: Failed to convert Dataset to ImagePlus.");
-            return;
+		
+		if (inputImagePlus == null && inputDataset == null) {
+			logService.error(CommonMessages.NO_IMAGE_OPEN);
+			return;
+		}
+		
+		//default to use inputImagePlus if it was provided
+		ImagePlus imp = inputImagePlus;
+		logService.info("Connectivity loading ImagePlus");
+		
+		//in case no ImagePlus was provided use the Dataset input
+		if (inputImagePlus == null) {
+			imp = convertService.convert(inputDataset, ImagePlus.class);
+			if (imp == null) {
+	            logService.error("Connectivity failed to convert Dataset to ImagePlus.");
+	            return;
+	        }
+			logService.info("Connectivity loaded Dataset and converted it to ImagePlus");
+		}
+		
+		//duplicate the dataset-derived imp if it's not native, to make it a native imp
+		//also loads VirtualStacks to memory.
+        if (!ImagePlusUtil.isNativeStack(imp)) {
+        	String title = imp.getTitle();
+        	imp = imp.duplicate();
+        	imp.setTitle(title);
+        	logService.info("Connectivity made a native ImagePlus in memory");
         }
-        
-        imp = imp.duplicate();
-        imp.setTitle(inputDataset.getName());
         
         if (!ImageCheck.isBinary(imp)) {
         	String errorMsg = "Connectivity requires a binary image. " +

--- a/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
+++ b/Legacy/bonej/src/main/java/org/bonej/plugins/Connectivity.java
@@ -140,6 +140,9 @@ public class Connectivity extends BoneJCommand implements Command {
             return;
         }
         
+        imp = imp.duplicate();
+        imp.setTitle(inputDataset.getName());
+        
         if (!ImageCheck.isBinary(imp)) {
         	String errorMsg = "Connectivity requires a binary image. " +
         			"The provided image (" + imp.getTitle() + ") is not binary.";

--- a/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
@@ -28,13 +28,18 @@
  */
 package org.bonej.utilities;
 
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ShortProcessor;
+
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
 import net.imagej.axis.Axes;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.array.ArrayImg;
-import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
@@ -54,8 +59,15 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.scijava.convert.ConvertService;
+
 /**
  * Utility class for loading raw binary 3D image data into ImageJ2 Datasets.
+ * <p>
+ * This class constructs Datasets by wrapping native ImageJ1 ImagePlus objects.
+ * This ensures that when legacy plugins convert these Datasets back to ImagePlus,
+ * they receive the original native byte[]/short[]/float[] arrays, avoiding the
+ * performance overhead of imglib2 wrappers.
  */
 public final class DatasetUtil {
 
@@ -78,7 +90,7 @@ public final class DatasetUtil {
 	 * @param spacingY      Voxel spacing in Y (mm)
 	 * @param spacingZ      Voxel spacing in Z (mm)
 	 * @param datasetService The DatasetService for creating the Dataset
-	 * @return A calibrated 3D Dataset
+	 * @return A calibrated 3D Dataset backed by a native ImagePlus
 	 * @throws IOException if the file cannot be read or is too small
 	 * @throws IllegalArgumentException if parameters are invalid
 	 */
@@ -107,12 +119,12 @@ public final class DatasetUtil {
 		String pt = pixelType.toLowerCase();
 		int bytesPerPixel;
 		switch (pt) {
-		case "uint8":   bytesPerPixel = 1; break;
-		case "uint16":  bytesPerPixel = 2; break;
-		case "int16":   bytesPerPixel = 2; break;
-		case "float32": bytesPerPixel = 4; break;
-		default:
-			throw new IllegalArgumentException("Unsupported pixel type: " + pixelType);
+			case "uint8":   bytesPerPixel = 1; break;
+			case "uint16":  bytesPerPixel = 2; break;
+			case "int16":   bytesPerPixel = 2; break;
+			case "float32": bytesPerPixel = 4; break;
+			default:
+				throw new IllegalArgumentException("Unsupported pixel type: " + pixelType);
 		}
 
 		long totalPixels = (long) width * height * depth;
@@ -129,18 +141,16 @@ public final class DatasetUtil {
 		// --- Read raw bytes, skipping header ---
 		byte[] rawData = readRawBytes(filePath, headerOffset, (int) expectedDataBytes);
 
-		//multiply 1s by 255 so that we have an ImageJ convention (0,255) binary image
+		// Convert 0/1 binary to 0/255 if requested (for 8-bit only)
 		if (zeroOneBinary && bytesPerPixel == 1) {
 			for (int i = 0; i < rawData.length; i++) {
 				byte byteValue = rawData[i];
 				if ((byteValue & ~1) != 0) {
-					// Provide context about the bad value
 					throw new IllegalArgumentException(
 							String.format("Non-binary value detected at index %d: %d (0x%02X)", 
 									i, byteValue, byteValue & 0xFF));
 				}
-
-				// Convert: 0 -> 0, 1 -> 255 (stored as -1)
+				// Convert: 0 -> 0, 1 -> 255 (stored as -1 in signed byte)
 				rawData[i] = (byte) ((byteValue * 255) & 0xFF);
 			}
 		}
@@ -150,7 +160,7 @@ public final class DatasetUtil {
 				? ByteOrder.BIG_ENDIAN
 						: ByteOrder.LITTLE_ENDIAN;
 
-		// --- Build Dataset ---
+		// --- Build Dataset (via Native ImagePlus) ---
 		Dataset dataset = buildDataset(rawData, width, height, depth, pt, order, datasetService);
 
 		// --- Apply metadata ---
@@ -193,20 +203,6 @@ public final class DatasetUtil {
 
 	/**
 	 * Overloaded version of loadRaw3D that does no (0,1) -> (0,255) binary conversion.
-	 * 
-	 * @param filePath
-	 * @param headerOffset
-	 * @param width
-	 * @param height
-	 * @param depth
-	 * @param pixelType
-	 * @param byteOrder
-	 * @param spacingX
-	 * @param spacingY
-	 * @param spacingZ
-	 * @param datasetService
-	 * @return
-	 * @throws IOException
 	 */
 	public static Dataset loadRaw3D(
 			File filePath,
@@ -224,8 +220,8 @@ public final class DatasetUtil {
 	}
 
 	/**
-	 * Constructs a Dataset from raw bytes based on pixel type.
-	 * Each branch uses the concrete type so Java infers generics correctly.
+	 * Constructs a Dataset by creating a native ImagePlus first, then wrapping it.
+	 * This ensures fast access for legacy plugins that expect native byte[] arrays.
 	 */
 	static Dataset buildDataset(
 			byte[] rawData,
@@ -234,42 +230,76 @@ public final class DatasetUtil {
 			ByteOrder byteOrder,
 			DatasetService datasetService) {
 
-		Dataset dataset;
+		ImagePlus imp;
 
 		if ("uint8".equals(pixelType)) {
-			var img = ArrayImgs.unsignedBytes(rawData, width, height, depth);
-			dataset = datasetService.create(img);
+			// Create native ImageStack with byte[] slices
+			ImageStack stack = new ImageStack(width, height);
+			int sliceSize = width * height;
+			for (int z = 0; z < depth; z++) {
+				byte[] slicePixels = new byte[sliceSize];
+				System.arraycopy(rawData, z * sliceSize, slicePixels, 0, sliceSize);
+				ByteProcessor bp = new ByteProcessor(width, height, slicePixels);
+				stack.addSlice("", bp);
+			}
+			imp = new ImagePlus("", stack);
 
 		} else if ("uint16".equals(pixelType)) {
+			// Unpack to short array first
 			short[] pixels = new short[rawData.length / 2];
 			ByteBuffer.wrap(rawData).order(byteOrder).asShortBuffer().get(pixels);
-			var img = ArrayImgs.unsignedShorts(pixels, width, height, depth);
-			dataset = datasetService.create(img);
+
+			ImageStack stack = new ImageStack(width, height);
+			int sliceSize = width * height;
+			for (int z = 0; z < depth; z++) {
+				short[] slicePixels = new short[sliceSize];
+				System.arraycopy(pixels, z * sliceSize, slicePixels, 0, sliceSize);
+				ShortProcessor sp = new ShortProcessor(width, height, slicePixels, null);
+				stack.addSlice("", sp);
+			}
+			imp = new ImagePlus("", stack);
 
 		} else if ("int16".equals(pixelType)) {
+			// Unpack to short array (signed)
 			short[] pixels = new short[rawData.length / 2];
 			ByteBuffer.wrap(rawData).order(byteOrder).asShortBuffer().get(pixels);
-			var img = ArrayImgs.shorts(pixels, width, height, depth);
-			dataset = datasetService.create(img);
+
+			ImageStack stack = new ImageStack(width, height);
+			int sliceSize = width * height;
+			for (int z = 0; z < depth; z++) {
+				short[] slicePixels = new short[sliceSize];
+				System.arraycopy(pixels, z * sliceSize, slicePixels, 0, sliceSize);
+				ShortProcessor sp = new ShortProcessor(width, height, slicePixels, null);
+				stack.addSlice("", sp);
+			}
+			imp = new ImagePlus("", stack);
 
 		} else { // float32
 			float[] pixels = new float[rawData.length / 4];
 			ByteBuffer.wrap(rawData).order(byteOrder).asFloatBuffer().get(pixels);
-			var img = ArrayImgs.floats(pixels, width, height, depth);
-			dataset = datasetService.create(img);
+
+			ImageStack stack = new ImageStack(width, height);
+			int sliceSize = width * height;
+			for (int z = 0; z < depth; z++) {
+				float[] slicePixels = new float[sliceSize];
+				System.arraycopy(pixels, z * sliceSize, slicePixels, 0, sliceSize);
+				FloatProcessor fp = new FloatProcessor(width, height, slicePixels);
+				stack.addSlice("", fp);
+			}
+			imp = new ImagePlus("", stack);
 		}
 
-		return dataset;
+		// Convert the native ImagePlus to a Dataset.
+		// This preserves the underlying native arrays, enabling fast round-trips.
+		ConvertService convertService = datasetService.getContext().getService(ConvertService.class);
+		return convertService.convert(imp, Dataset.class);
 	}
 
 	/**
 	 * Writes the pixel data of a 3D Dataset to a raw binary file.
 	 * Uses ArrayDataAccess to get the backing array efficiently (no reflection).
-	 *
-	 * @param dataset      The source 3D Dataset.
-	 * @param outputFile   The destination file path.
-	 * @param littleEndian If true, writes as Little-Endian (default). If false, writes Big-Endian.
-	 * @param zeroOneBinary If true, converts 8-bit (0,255) binary to 8-bit (0,1) binary. Ignored if the image is not 8-bit.
+	 * If the Dataset is backed by a native ImagePlus (not an ArrayImg), it falls back
+	 * to cursor iteration to write the data correctly.
 	 */
 	public static void saveAsRaw(Dataset dataset, File outputFile, boolean littleEndian, boolean zeroOneBinary) throws IOException {
 		if (dataset.numDimensions() != 3) {
@@ -296,6 +326,7 @@ public final class DatasetUtil {
 		System.out.println("img class = " + img.getClass().getName());
 		long start = System.nanoTime();
 		long end = start;
+		
 		if (img instanceof ArrayImg) {
 			System.out.println("Using fast path for Dataset-> RAW");
 			try (FileOutputStream fos = new FileOutputStream(outputFile);

--- a/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/DatasetUtil.java
@@ -566,4 +566,20 @@ public final class DatasetUtil {
 	public static void saveAsRaw(Dataset dataset, File outputFile) throws IOException {
 		saveAsRaw(dataset, outputFile, true, false);
 	}
+	
+	/**
+	 * Converts a Dataset to an ImagePlus
+	 * 
+	 * @param dataset
+	 * @param datasetService
+	 * @return A legacy ImagePlus backed by in-memory ImageStack primitive arrays.
+	 */
+	public static ImagePlus toImagePlus(Dataset dataset, DatasetService datasetService) {
+		ConvertService convertService = (ConvertService) datasetService.getContext().getService(DatasetService.class);
+		ImagePlus imp = convertService.convert(dataset, ImagePlus.class);
+		if (!ImagePlusUtil.isNativeStack(imp))
+			imp = imp.duplicate();
+		imp.setTitle(dataset.getName());
+		return imp;
+	}
 }

--- a/Modern/utilities/src/main/java/org/bonej/utilities/ImagePlusUtil.java
+++ b/Modern/utilities/src/main/java/org/bonej/utilities/ImagePlusUtil.java
@@ -33,6 +33,7 @@ package org.bonej.utilities;
 import java.util.Arrays;
 
 import ij.ImagePlus;
+import ij.ImageStack;
 import ij.measure.Calibration;
 
 /**
@@ -113,5 +114,37 @@ public final class ImagePlusUtil {
 	public static boolean isBinaryColour(final ImagePlus image) {
 		return Arrays.stream(image.getStatistics().histogram).filter(p -> p > 0)
 			.count() <= 2;
+	}
+	
+	/**
+	 * Checks if the ImageStack contains native arrays that can be accessed directly from the heap.
+	 * Returns true if safe to access directly without duplication.
+	 * Returns false if the stack uses wrappers, VirtualStacks, or other non-native representations.
+	 * 
+	 * @param imp ImagePlus to check
+	 * @return true if safe to access imp directly without duplication or false if the stack
+	 * uses wrappers, VirtualStacks, or other non-native representations, or if there was an exception.
+	 */
+	public static boolean isNativeStack(final ImagePlus imp) {
+		try {
+			ImageStack stack = imp.getStack();
+			
+			// Check if the stack itself is a VirtualStack (which implies lazy loading/wrapping)
+			if (stack instanceof ij.VirtualStack) {
+				return false;
+			}
+
+			// Get the pixels for the first slice (1-based index)
+			Object pixels = stack.getPixels(1);
+			
+			// Verify it is a primitive byte, short, float or int array
+			return (pixels instanceof byte[] ||
+					pixels instanceof short[] ||
+					pixels instanceof float[] ||
+					pixels instanceof int[]);
+		} catch (Exception e) {
+			// If anything fails (e.g., empty stack, weird state), assume non-native to be safe
+			return false;
+		}
 	}
 }

--- a/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
+++ b/Modern/utilities/src/test/java/org/bonej/utilities/DatasetUtilTest.java
@@ -46,6 +46,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,8 +61,6 @@ import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for DatasetUtil.
- * Note: Full integration tests require a real ImageJ context.
- * These tests focus on validation, file I/O logic, and byte manipulation.
  */
 public class DatasetUtilTest {
 
@@ -68,35 +68,37 @@ public class DatasetUtilTest {
 	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	private DatasetService mockDatasetService;
+	private Context mockContext;
+	private ConvertService mockConvertService;
 
 	@Before
 	public void setUp() {
-		// Mock the service to avoid needing a full ImageJ context for basic tests
 		mockDatasetService = mock(DatasetService.class);
+		mockContext = mock(Context.class);
+		mockConvertService = mock(ConvertService.class);
 
-		// Since we can't easily create a real Dataset without an ImageJ instance,
-		// we will test the static helper methods that don't strictly require it
-		// or use mocks where necessary.
-		// For buildDataset, we expect it to fail if called without a working service,
-		// so we'll primarily test readRawBytes and validation logic here.
+		// Wire up: datasetService.getContext() → mockContext
+		when(mockDatasetService.getContext()).thenReturn(mockContext);
+
+		// Wire up: context.getService(ConvertService.class) → mockConvertService
+		when(mockContext.getService(ConvertService.class)).thenReturn(mockConvertService);
 	}
 
 	@After
 	public void tearDown() {
 		mockDatasetService = null;
+		mockContext = null;
+		mockConvertService = null;
 	}
 
-	/**
-	 * Test that loadRaw3D throws IllegalArgumentException for invalid dimensions.
-	 */
+	// ========== Validation Tests ==========
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testLoadRaw3D_InvalidWidth() throws Exception {
 		File dummy = tempFolder.newFile("dummy.raw");
-		dummy.deleteOnExit(); // Just needs to exist
-
 		DatasetUtil.loadRaw3D(
 				dummy, 0, -5, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
+		);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -104,7 +106,7 @@ public class DatasetUtilTest {
 		File dummy = tempFolder.newFile("dummy.raw");
 		DatasetUtil.loadRaw3D(
 				dummy, 0, 10, 0, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
+		);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -112,142 +114,85 @@ public class DatasetUtilTest {
 		File dummy = tempFolder.newFile("dummy.raw");
 		DatasetUtil.loadRaw3D(
 				dummy, 0, 10, 10, -1, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
+		);
 	}
 
-	/**
-	 * Test that loadRaw3D throws IllegalArgumentException for non-existent file.
-	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void testLoadRaw3D_NonExistentFile() throws Exception {
 		File nonexistent = new File("/nonexistent/dummy.raw");
 		DatasetUtil.loadRaw3D(
 				nonexistent, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
+		);
 	}
 
-	/**
-	 * Test that loadRaw3D throws IllegalArgumentException for unsupported pixel type.
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testLoadRaw3D_UnsupportedPixelType() throws Exception {
-		File file = tempFolder.newFile("test.raw");
-		Files.write(file.toPath(), new byte[100]);
-
-		DatasetUtil.loadRaw3D(
-				file, 0, 5, 5, 4, "invalid_type", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
-	}
-
-	/**
-	 * Test that loadRaw3D throws IOException when file is too small.
-	 */
-	@Test(expected = IOException.class)
-	public void testLoadRaw3D_FileTooSmall() throws Exception {
-		// Need 10x10x10 uint8 = 1000 bytes. File has only 10.
-		byte[] smallData = new byte[10];
-		File file = writeDataToFile(smallData, "small.raw");
-
-		DatasetUtil.loadRaw3D(
-				file, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
-				);
-	}
-
-	/**
-	 * Test readRawBytes reads correctly with no offset.
-	 */
-	@Test
-	public void testReadRawBytes_NoOffset() throws Exception {
-		byte[] expected = {1, 2, 3, 4, 5};
-		File file = writeDataToFile(expected, "read_test.raw");
-
-		byte[] result = DatasetUtil.readRawBytes(file, 0, 5);
-
-		assertArrayEquals("Data should match exactly", expected, result);
-	}
-
-	/**
-	 * Test readRawBytes skips header correctly.
-	 */
-	@Test
-	public void testReadRawBytes_WithHeaderOffset() throws Exception {
-		byte[] header = {-1, -2, -3, 4, 5}; // Header data
-		byte[] payload = {10, 20, 30};      // Data to read
-
-		byte[] combined = new byte[header.length + payload.length];
-		System.arraycopy(header, 0, combined, 0, header.length);
-		System.arraycopy(payload, 0, combined, header.length, payload.length);
-
-		File file = writeDataToFile(combined, "offset_test.raw");
-
-		byte[] result = DatasetUtil.readRawBytes(file, header.length, payload.length);
-
-		assertArrayEquals("Payload should be read after skipping header", payload, result);
-
-		// Verify header was skipped
-		assertNotEquals("Header content should not be in result", 
-				header[0], result[0]);
-	}
-
-	/**
-	 * Test readRawBytes handles partial reads correctly (simulated by large buffer).
-	 */
-	@Test
-	public void testReadRawBytes_LargeBlock() throws Exception {
-		int size = 1024;
-		byte[] data = new byte[size];
-		for(int i=0; i<size; i++) data[i] = (byte)(i % 256);
-
-		File file = writeDataToFile(data, "large_block.raw");
-
-		byte[] result = DatasetUtil.readRawBytes(file, 0, size);
-
-		assertArrayEquals("Large block read failed", data, result);
-	}
-
-	/**
-	 * Test saveAsRaw method existence and basic parameter handling.
-	 * Actual functionality requires a populated Dataset which is hard to mock without ImageJ.
-	 */
-	@Test
-	public void testSaveAsRaw_MethodExists() throws Exception {
-		// Verify the method signature exists
-		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class, boolean.class);
-		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class);
-	}
-
-	// Helper to create a test file with data
-	private File writeDataToFile(byte[] data, String filename) throws Exception {
-		File file = tempFolder.newFile(filename);
-		java.nio.file.Files.write(file.toPath(), data);
-		return file;
-	}
-
-
-	//^ ^Tests wrking above this line =========
-	/**
-	 * Test that loadRaw3D throws IllegalArgumentException for null file.
-	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void testLoadRaw3D_NullFile() throws Exception {
 		DatasetUtil.loadRaw3D(null, 0, 10, 10, 10, "uint8",
 				"Little-endian", 1.0, 1.0, 1.0, mockDatasetService);
 	}
 
-	/**
-	 * Test that loadRaw3D throws IOException when header offset exceeds file size.
-	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadRaw3D_UnsupportedPixelType() throws Exception {
+		File file = tempFolder.newFile("test.raw");
+		Files.write(file.toPath(), new byte[100]);
+		DatasetUtil.loadRaw3D(
+				file, 0, 5, 5, 4, "invalid_type", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+		);
+	}
+
+	@Test(expected = IOException.class)
+	public void testLoadRaw3D_FileTooSmall() throws Exception {
+		byte[] smallData = new byte[10];
+		File file = writeDataToFile(smallData, "small.raw");
+		DatasetUtil.loadRaw3D(
+				file, 0, 10, 10, 10, "uint8", "Little-endian", 1.0, 1.0, 1.0, mockDatasetService
+		);
+	}
+
 	@Test(expected = IOException.class)
 	public void testLoadRaw3D_HeaderOffsetExceedsFile() throws Exception {
-		// 10-byte file, 100-byte header offset means we can't even skip the header
 		File file = writeDataToFile(new byte[10], "tiny.raw");
 		DatasetUtil.loadRaw3D(file, 100, 2, 2, 2, "uint8",
 				"Little-endian", 1.0, 1.0, 1.0, mockDatasetService);
 	}
 
-	/**
-	 * Test readRawBytes with zero-length read (should return empty array, not throw).
-	 */
+	// ========== readRawBytes Tests ==========
+
+	@Test
+	public void testReadRawBytes_NoOffset() throws Exception {
+		byte[] expected = {1, 2, 3, 4, 5};
+		File file = writeDataToFile(expected, "read_test.raw");
+		byte[] result = DatasetUtil.readRawBytes(file, 0, 5);
+		assertArrayEquals("Data should match exactly", expected, result);
+	}
+
+	@Test
+	public void testReadRawBytes_WithHeaderOffset() throws Exception {
+		byte[] header = {-1, -2, -3, 4, 5};
+		byte[] payload = {10, 20, 30};
+		byte[] combined = new byte[header.length + payload.length];
+		System.arraycopy(header, 0, combined, 0, header.length);
+		System.arraycopy(payload, 0, combined, header.length, payload.length);
+
+		File file = writeDataToFile(combined, "offset_test.raw");
+		byte[] result = DatasetUtil.readRawBytes(file, header.length, payload.length);
+
+		assertArrayEquals("Payload should be read after skipping header", payload, result);
+		assertNotEquals("Header content should not be in result", header[0], result[0]);
+	}
+
+	@Test
+	public void testReadRawBytes_LargeBlock() throws Exception {
+		int size = 1024;
+		byte[] data = new byte[size];
+		for (int i = 0; i < size; i++) data[i] = (byte) (i % 256);
+
+		File file = writeDataToFile(data, "large_block.raw");
+		byte[] result = DatasetUtil.readRawBytes(file, 0, size);
+
+		assertArrayEquals("Large block read failed", data, result);
+	}
+
 	@Test
 	public void testReadRawBytes_ZeroLengthRead() throws Exception {
 		byte[] data = {1, 2, 3};
@@ -256,123 +201,103 @@ public class DatasetUtilTest {
 		assertEquals("Zero-length read should return empty array", 0, result.length);
 	}
 
-	/**
-	 * Test readRawBytes fails if requested bytes exceed actual file size after offset.
-	 */
 	@Test(expected = IOException.class)
 	public void testReadRawBytes_TruncatedFile() throws Exception {
-		// Request 100 bytes but file only has 50
 		File file = writeDataToFile(new byte[50], "truncated.raw");
 		DatasetUtil.readRawBytes(file, 0, 100);
 	}
 
+	// ========== buildDataset Tests ==========
+
 	/**
-	 * Test buildDataset creates correct type for uint8.
+	 * Helper that creates a mock Dataset to return from ConvertService.convert(),
+	 * wrapping the converted ImagePlus metadata where possible.
 	 */
+	private Dataset stubConvertAndReturnMock() {
+		Dataset mockDs = mock(Dataset.class);
+		when(mockConvertService.convert(any(ij.ImagePlus.class), eq(Dataset.class)))
+				.thenReturn(mockDs);
+		return mockDs;
+	}
+
 	@Test
 	public void testBuildDataset_Uint8() throws Exception {
+		Dataset expectedDs = stubConvertAndReturnMock();
+
 		int w = 4, h = 3, d = 2;
 		byte[] rawData = new byte[w * h * d];
 		for (int i = 0; i < rawData.length; i++) rawData[i] = (byte) i;
 
-		// Create a mock Dataset
-		Dataset mockDs = mock(Dataset.class);
-
-		// Stub DatasetService.create to return the mock Dataset for any Img
-		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
-
-		// Call buildDataset
 		Dataset result = DatasetUtil.buildDataset(
 				rawData, w, h, d, "uint8", ByteOrder.LITTLE_ENDIAN, mockDatasetService
-				);
+		);
 
-		// Verify the result is the mock Dataset
-		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
-
-		// Verify DatasetService.create was called with an Img
-		verify(mockDatasetService).create(any(Img.class));
+		assertSame("buildDataset should return the converted Dataset", expectedDs, result);
+		verify(mockConvertService).convert(any(ij.ImagePlus.class), eq(Dataset.class));
+		verify(mockDatasetService).getContext();
 	}
 
-	/**
-	 * Test buildDataset creates correct type for uint16.
-	 */
 	@Test
 	public void testBuildDataset_Uint16() throws Exception {
+		Dataset expectedDs = stubConvertAndReturnMock();
+
 		int w = 2, h = 2, d = 2;
 		short[] values = {100, 2000, 30000, 500, 999, 1234, 32000, 0};
 		ByteBuffer bb = ByteBuffer.allocate(values.length * 2).order(ByteOrder.LITTLE_ENDIAN);
 		bb.asShortBuffer().put(values);
 
-		Dataset mockDs = mock(Dataset.class);
-		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
-
 		Dataset result = DatasetUtil.buildDataset(
 				bb.array(), w, h, d, "uint16", ByteOrder.LITTLE_ENDIAN, mockDatasetService
-				);
+		);
 
-		assertSame(mockDs, result);
-		verify(mockDatasetService).create(any(Img.class));
+		assertSame(expectedDs, result);
+		verify(mockConvertService).convert(any(ij.ImagePlus.class), eq(Dataset.class));
 	}
 
-	/**
-	 * Test buildDataset creates correct type for int16 (including negatives).
-	 */
 	@Test
 	public void testBuildDataset_Int16() throws Exception {
+		Dataset expectedDs = stubConvertAndReturnMock();
+
 		int w = 2, h = 2, d = 2;
 		short[] values = {-100, 2000, -30000, 500, -999, 1234, -1, 0};
 		ByteBuffer bb = ByteBuffer.allocate(values.length * 2).order(ByteOrder.LITTLE_ENDIAN);
 		bb.asShortBuffer().put(values);
 
-		// Create a mock Dataset
-		Dataset mockDs = mock(Dataset.class);
-
-		// Stub DatasetService.create to return the mock Dataset for any Img
-		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
-
-		// Call buildDataset
 		Dataset result = DatasetUtil.buildDataset(
 				bb.array(), w, h, d, "int16", ByteOrder.LITTLE_ENDIAN, mockDatasetService
-				);
+		);
 
-		// Verify the result is the mock Dataset
-		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
-
-		// Verify DatasetService.create was called with an Img
-		verify(mockDatasetService).create(any(Img.class));
+		assertSame(expectedDs, result);
+		verify(mockConvertService).convert(any(ij.ImagePlus.class), eq(Dataset.class));
 	}
 
-	/**
-	 * Test buildDataset creates correct type for float32 (including NaN/Inf).
-	 */
 	@Test
 	public void testBuildDataset_Float32() throws Exception {
+		Dataset expectedDs = stubConvertAndReturnMock();
+
 		int w = 2, h = 2, d = 2;
 		float[] values = {1.0f, -2.5f, 3.14f, 0.0f, 100.0f, -0.001f, 1e10f, Float.NaN};
 		ByteBuffer bb = ByteBuffer.allocate(values.length * 4).order(ByteOrder.BIG_ENDIAN);
 		bb.asFloatBuffer().put(values);
 
-		// Create a mock Dataset
-		Dataset mockDs = mock(Dataset.class);
-
-		// Stub DatasetService.create to return the mock Dataset for any Img
-		when(mockDatasetService.create(any(Img.class))).thenReturn(mockDs);
-
-		// Call buildDataset
 		Dataset result = DatasetUtil.buildDataset(
 				bb.array(), w, h, d, "float32", ByteOrder.BIG_ENDIAN, mockDatasetService
-				);
+		);
 
-		// Verify the result is the mock Dataset
-		assertSame("buildDataset should return the mocked Dataset", mockDs, result);
-
-		// Verify DatasetService.create was called with an Img
-		verify(mockDatasetService).create(any(Img.class));
+		assertSame(expectedDs, result);
+		verify(mockConvertService).convert(any(ij.ImagePlus.class), eq(Dataset.class));
 	}
 
-	/**
-	 * Round-trip test: Write uint8 ArrayImg to raw file and read back.
-	 */
+	// ========== saveAsRaw Method Existence ==========
+
+	@Test
+	public void testSaveAsRaw_MethodExists() throws Exception {
+		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class, boolean.class);
+		DatasetUtil.class.getMethod("saveAsRaw", Dataset.class, File.class);
+	}
+
+	// ========== saveAsRaw Round-Trip Tests ==========
+
 	@Test
 	public void testSaveAsRaw_Uint8ArrayImg() throws Exception {
 		int w = 4, h = 3, d = 2;
@@ -397,9 +322,6 @@ public class DatasetUtilTest {
 		assertArrayEquals("uint8 round-trip failed", expectedBytes, written);
 	}
 
-	/**
-	 * Round-trip test: Write uint16 ArrayImg to raw file (Little-Endian) and read back.
-	 */
 	@Test
 	public void testSaveAsRaw_Uint16ArrayImg_LittleEndian() throws Exception {
 		int w = 3, h = 2, d = 2;
@@ -427,9 +349,6 @@ public class DatasetUtilTest {
 		assertArrayEquals("uint16 LE round-trip failed", expectedValues, result);
 	}
 
-	/**
-	 * Round-trip test: Write uint16 ArrayImg to raw file (Big-Endian) and read back.
-	 */
 	@Test
 	public void testSaveAsRaw_Uint16ArrayImg_BigEndian() throws Exception {
 		int w = 2, h = 2, d = 2;
@@ -457,9 +376,6 @@ public class DatasetUtilTest {
 		assertArrayEquals("uint16 BE round-trip failed", expectedValues, result);
 	}
 
-	/**
-	 * Round-trip test: Write float32 ArrayImg to raw file (Little-Endian) and read back.
-	 */
 	@Test
 	public void testSaveAsRaw_Float32ArrayImg_LittleEndian() throws Exception {
 		int w = 2, h = 3, d = 2;
@@ -525,7 +441,7 @@ public class DatasetUtilTest {
 		int w = 2, h = 2, d = 1;
 		ArrayImg<UnsignedShortType, ShortArray> img = ArrayImgs.unsignedShorts(w, h, d);
 
-		short val = 0x0102; // Distinct high/low bytes
+		short val = 0x0102;
 		var cursor = img.cursor();
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -535,7 +451,7 @@ public class DatasetUtilTest {
 		Dataset ds = wrapInMockDataset(img, w, h, d);
 		File outFile = tempFolder.newFile("out_default_endian.raw");
 
-		DatasetUtil.saveAsRaw(ds, outFile); // No endian arg -> default (LE)
+		DatasetUtil.saveAsRaw(ds, outFile);
 
 		byte[] written = Files.readAllBytes(outFile.toPath());
 		// Little-endian: low byte first → 0x02, 0x01
@@ -549,16 +465,15 @@ public class DatasetUtilTest {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void testSaveAsRaw_Non3DDataset() throws Exception {
-		ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(4, 3); // 2D
+		ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(4, 3);
 		Dataset ds = wrapInMockDataset(img, 4, 3);
 
 		File outFile = tempFolder.newFile("out_2d.raw");
 		DatasetUtil.saveAsRaw(ds, outFile);
 	}
 
-	/**
-	 * Improved endianness check using Arrays.equals instead of hashCode.
-	 */
+	// ========== Endianness Tests ==========
+
 	@Test
 	public void testEndiannessConversion() {
 		short[] shorts = {1, 258, 513};
@@ -586,20 +501,20 @@ public class DatasetUtilTest {
 				Arrays.equals(leF.array(), beF.array()));
 	}
 
-	/**
-	 * Helper to create a mock Dataset wrapping a real ArrayImg.
-	 * Uses raw types for Mockito stubbing to avoid wildcard issues.
-	 */
+	// ========== Helpers ==========
+
+	private File writeDataToFile(byte[] data, String filename) throws Exception {
+		File file = tempFolder.newFile(filename);
+		java.nio.file.Files.write(file.toPath(), data);
+		return file;
+	}
+
 	@SuppressWarnings("unchecked")
 	private Dataset wrapInMockDataset(Object imgObj, long... dims) {
-		// Cast the input image to the raw Img interface
 		Img img = (Img) imgObj;
-
-		// Create mocks using raw types
 		Dataset ds = mock(Dataset.class);
 		ImgPlus imgPlus = mock(ImgPlus.class);
 
-		// Stub the methods using raw types
 		when(ds.numDimensions()).thenReturn(dims.length);
 		when(ds.getImgPlus()).thenReturn(imgPlus);
 		when(imgPlus.getImg()).thenReturn(img);


### PR DESCRIPTION
Connectivity relies on fast access to the primitive `byte[]` arrays backing an `ImageStack`. Wrapped `Dataset` images are slow to access.

Provide a fast path for clients that can provide native `ImagePlus` as a `@Parameter` and for those that have to provide a `Dataset` do a conversion to `ImagePlus` backed by in-memory primitive arrays.